### PR TITLE
Transaction modal CSS customization

### DIFF
--- a/client/dom-utils.ts
+++ b/client/dom-utils.ts
@@ -1,0 +1,9 @@
+export function getFocusableElements(container: HTMLElement) {
+	const selector =
+		'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+	const candidates = Array.from(container.querySelectorAll(selector))
+	return candidates.filter(
+		(element): element is HTMLElement =>
+			element instanceof HTMLElement && element.tabIndex >= 0,
+	)
+}

--- a/client/dom-utils.ts
+++ b/client/dom-utils.ts
@@ -7,3 +7,39 @@ export function getFocusableElements(container: HTMLElement) {
 			element instanceof HTMLElement && element.tabIndex >= 0,
 	)
 }
+
+export function handleModalKeydown(event: KeyboardEvent, onClose: () => void) {
+	if (event.key === 'Escape') {
+		event.preventDefault()
+		onClose()
+		return
+	}
+
+	if (event.key !== 'Tab') return
+	if (!(event.currentTarget instanceof HTMLElement)) return
+
+	const focusableElements = getFocusableElements(event.currentTarget)
+	if (focusableElements.length === 0) {
+		event.preventDefault()
+		return
+	}
+
+	const activeElement = document.activeElement
+	const firstFocusableElement = focusableElements[0]
+	const lastFocusableElement = focusableElements[focusableElements.length - 1]
+	if (!firstFocusableElement || !lastFocusableElement) return
+	const activeInModal = focusableElements.includes(activeElement as HTMLElement)
+
+	if (event.shiftKey) {
+		if (activeElement === firstFocusableElement || !activeInModal) {
+			event.preventDefault()
+			lastFocusableElement.focus()
+		}
+		return
+	}
+
+	if (activeElement === lastFocusableElement || !activeInModal) {
+		event.preventDefault()
+		firstFocusableElement.focus()
+	}
+}

--- a/client/ledger-api.ts
+++ b/client/ledger-api.ts
@@ -149,7 +149,11 @@ export async function fetchTransactions(query: URLSearchParams) {
 	} satisfies LedgerTransactionsPage
 }
 
-export async function createKid(input: { name: string; emoji: string }) {
+export async function createKid(input: {
+	name: string
+	emoji: string
+	transactionModalCss?: string
+}) {
 	return postJson<{ ok: true; kidId: number }>('/ledger/kids/create', input)
 }
 

--- a/client/ledger-api.ts
+++ b/client/ledger-api.ts
@@ -13,6 +13,7 @@ export type KidSummary = {
 	householdId: number
 	name: string
 	emoji: string
+	transactionModalCss: string
 	sortOrder: number
 	isArchived: boolean
 	totalBalanceCents: number
@@ -156,6 +157,7 @@ export async function updateKid(input: {
 	kidId: number
 	name: string
 	emoji: string
+	transactionModalCss?: string
 }) {
 	return postJson<{ ok: true }>('/ledger/kids/update', input)
 }

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -18,6 +18,7 @@ import {
 } from '#client/styles/tokens.ts'
 import { inputCss, buttonCss } from '#client/styles/form-controls.ts'
 import { buildTransactionModalCss } from '#client/styles/transaction-modal-css.ts'
+import { getFocusableElements } from '#client/dom-utils.ts'
 
 type TransactionState = {
 	kid: KidSummary
@@ -30,16 +31,6 @@ type TransactionState = {
 }
 
 const modalCloseAnimationDurationMs = 220
-
-function getFocusableElements(container: HTMLElement) {
-	const selector =
-		'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-	const candidates = Array.from(container.querySelectorAll(selector))
-	return candidates.filter(
-		(element): element is HTMLElement =>
-			element instanceof HTMLElement && element.tabIndex >= 0,
-	)
-}
 
 export function HomeRoute(handle: Handle) {
 	let status: 'loading' | 'ready' | 'error' = 'loading'

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -593,7 +593,12 @@ function modalButtonCss(
 function buildTransactionModalCustomCss(transactionModalCss: string) {
 	const trimmed = transactionModalCss.trim()
 	if (!trimmed) return ''
-	return `[data-kid-transaction-modal] {\n${trimmed}\n}`
+	if (isLikelyCssStylesheet(trimmed)) return trimmed
+	return `:root {\n${trimmed}\n}`
+}
+
+function isLikelyCssStylesheet(cssText: string) {
+	return cssText.includes('{') || cssText.includes('@')
 }
 
 function LoggedOutHome() {

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -53,6 +53,15 @@ export function HomeRoute(handle: Handle) {
 	let transactionModalClosing = false
 	let closeModalTimeoutId: number | null = null
 
+	function removeTransactionModalStyles() {
+		if (typeof document === 'undefined') return
+		for (const element of document.querySelectorAll(
+			'style[data-kid-transaction-modal-css]',
+		)) {
+			element.remove()
+		}
+	}
+
 	function clearCloseModalTimeout() {
 		if (closeModalTimeoutId === null) return
 		window.clearTimeout(closeModalTimeoutId)
@@ -65,6 +74,7 @@ export function HomeRoute(handle: Handle) {
 		opener: HTMLButtonElement,
 	) {
 		clearCloseModalTimeout()
+		removeTransactionModalStyles()
 		transactionModalOpener = opener
 		transactionModalClosing = false
 		transactionState = {
@@ -95,6 +105,7 @@ export function HomeRoute(handle: Handle) {
 			transactionState = null
 			transactionModalClosing = false
 			closeModalTimeoutId = null
+			removeTransactionModalStyles()
 			handle.update()
 			if (opener?.isConnected) {
 				handle.queueTask(() => {
@@ -164,6 +175,12 @@ export function HomeRoute(handle: Handle) {
 
 	handle.queueTask(async () => {
 		await refreshDashboard()
+	})
+	handle.queueTask(() => {
+		return () => {
+			clearCloseModalTimeout()
+			removeTransactionModalStyles()
+		}
 	})
 
 	function setTransactionAmountFromQuick(cents: number) {
@@ -369,8 +386,7 @@ export function HomeRoute(handle: Handle) {
 							: 'modal-backdrop-in 180ms ease-out forwards',
 					}}
 				>
-					{!transactionModalClosing &&
-					transactionState.kid.transactionModalCss.trim() ? (
+					{transactionState.kid.transactionModalCss.trim() ? (
 						<style data-kid-transaction-modal-css>
 							{buildTransactionModalCss(
 								transactionState.kid.transactionModalCss,

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -368,17 +368,27 @@ export function HomeRoute(handle: Handle) {
 							: 'modal-backdrop-in 180ms ease-out forwards',
 					}}
 				>
+					{!transactionModalClosing &&
+					transactionState.kid.transactionModalCss.trim() ? (
+						<style data-kid-transaction-modal-css>
+							{buildTransactionModalCustomCss(
+								transactionState.kid.transactionModalCss,
+							)}
+						</style>
+					) : null}
 					<section
 						role="dialog"
 						aria-modal="true"
 						aria-labelledby="transaction-modal-title"
 						aria-describedby="transaction-modal-description"
+						data-kid-transaction-modal
 						on={{ keydown: handleTransactionModalKeydown }}
 						css={{
 							width: 'min(30rem, 100%)',
 							display: 'grid',
 							gap: spacing.md,
 							padding: spacing.lg,
+							fontFamily: typography.fontFamily,
 							borderRadius: radius.xl,
 							border: `3px solid ${colors.border}`,
 							backgroundColor: colors.surface,
@@ -578,6 +588,12 @@ function modalButtonCss(
 			boxShadow: `0 0 0 0 ${activeShadow}`,
 		},
 	}
+}
+
+function buildTransactionModalCustomCss(transactionModalCss: string) {
+	const trimmed = transactionModalCss.trim()
+	if (!trimmed) return ''
+	return `[data-kid-transaction-modal] {\n${trimmed}\n}`
 }
 
 function LoggedOutHome() {

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -17,6 +17,7 @@ import {
 	typography,
 } from '#client/styles/tokens.ts'
 import { inputCss, buttonCss } from '#client/styles/form-controls.ts'
+import { buildTransactionModalCss } from '#client/styles/transaction-modal-css.ts'
 
 type TransactionState = {
 	kid: KidSummary
@@ -371,7 +372,7 @@ export function HomeRoute(handle: Handle) {
 					{!transactionModalClosing &&
 					transactionState.kid.transactionModalCss.trim() ? (
 						<style data-kid-transaction-modal-css>
-							{buildTransactionModalCustomCss(
+							{buildTransactionModalCss(
 								transactionState.kid.transactionModalCss,
 							)}
 						</style>
@@ -588,17 +589,6 @@ function modalButtonCss(
 			boxShadow: `0 0 0 0 ${activeShadow}`,
 		},
 	}
-}
-
-function buildTransactionModalCustomCss(transactionModalCss: string) {
-	const trimmed = transactionModalCss.trim()
-	if (!trimmed) return ''
-	if (isLikelyCssStylesheet(trimmed)) return trimmed
-	return `:root {\n${trimmed}\n}`
-}
-
-function isLikelyCssStylesheet(cssText: string) {
-	return cssText.includes('{') || cssText.includes('@')
 }
 
 function LoggedOutHome() {

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -18,7 +18,7 @@ import {
 } from '#client/styles/tokens.ts'
 import { inputCss, buttonCss } from '#client/styles/form-controls.ts'
 import { buildTransactionModalCss } from '#client/styles/transaction-modal-css.ts'
-import { getFocusableElements } from '#client/dom-utils.ts'
+import { handleModalKeydown } from '#client/dom-utils.ts'
 
 type TransactionState = {
 	kid: KidSummary
@@ -107,41 +107,7 @@ export function HomeRoute(handle: Handle) {
 	}
 
 	function handleTransactionModalKeydown(event: KeyboardEvent) {
-		if (event.key === 'Escape') {
-			event.preventDefault()
-			closeTransactionModal()
-			return
-		}
-
-		if (event.key !== 'Tab') return
-		if (!(event.currentTarget instanceof HTMLElement)) return
-
-		const focusableElements = getFocusableElements(event.currentTarget)
-		if (focusableElements.length === 0) {
-			event.preventDefault()
-			return
-		}
-
-		const activeElement = document.activeElement
-		const firstFocusableElement = focusableElements[0]
-		const lastFocusableElement = focusableElements[focusableElements.length - 1]
-		if (!firstFocusableElement || !lastFocusableElement) return
-		const activeInModal = focusableElements.includes(
-			activeElement as HTMLElement,
-		)
-
-		if (event.shiftKey) {
-			if (activeElement === firstFocusableElement || !activeInModal) {
-				event.preventDefault()
-				lastFocusableElement.focus()
-			}
-			return
-		}
-
-		if (activeElement === lastFocusableElement || !activeInModal) {
-			event.preventDefault()
-			firstFocusableElement.focus()
-		}
+		handleModalKeydown(event, closeTransactionModal)
 	}
 
 	async function refreshDashboard() {

--- a/client/routes/settings.tsx
+++ b/client/routes/settings.tsx
@@ -128,11 +128,21 @@ const transactionModalCssVariables = [
 ] as const
 
 const transactionModalCssFontExample = `--font-family: "Comic Sans MS", "Comic Sans", cursive;`
+const transactionModalCssGoogleFontExample = `@import url("https://fonts.googleapis.com/css2?family=MedievalSharp&display=swap");
+
+:root {
+	--font-family: "MedievalSharp", cursive;
+}`
 
 function buildTransactionModalPreviewCss(transactionModalCss: string) {
 	const trimmed = transactionModalCss.trim()
 	if (!trimmed) return ''
-	return `[data-kid-transaction-modal-preview] {\n${trimmed}\n}`
+	if (isLikelyCssStylesheet(trimmed)) return trimmed
+	return `:root {\n${trimmed}\n}`
+}
+
+function isLikelyCssStylesheet(cssText: string) {
+	return cssText.includes('{') || cssText.includes('@')
 }
 
 type SettingsState =
@@ -1258,8 +1268,9 @@ export function SettingsRoute(handle: Handle) {
 											transaction modal
 										</h3>
 										<p css={{ margin: 0, color: colors.textMuted }}>
-											Enter CSS declarations. These only apply while this
-											kid&apos;s transaction modal is open.
+											Enter declarations or full CSS rules. When this kid&apos;s
+											transaction modal is open on Home, the styles apply to the
+											whole page.
 										</p>
 									</div>
 									<button
@@ -1400,6 +1411,24 @@ export function SettingsRoute(handle: Handle) {
 										}}
 									>
 										{transactionModalCssFontExample}
+									</pre>
+								</div>
+								<div css={{ display: 'grid', gap: spacing.xs }}>
+									<strong css={{ color: colors.text }}>
+										Google Fonts example
+									</strong>
+									<pre
+										css={{
+											margin: 0,
+											padding: spacing.sm,
+											borderRadius: radius.md,
+											border: `2px solid ${colors.border}`,
+											backgroundColor: colors.primarySoftest,
+											color: colors.text,
+											overflowX: 'auto',
+										}}
+									>
+										{transactionModalCssGoogleFontExample}
 									</pre>
 								</div>
 								{transactionModalCssSaveError ? (

--- a/client/routes/settings.tsx
+++ b/client/routes/settings.tsx
@@ -111,6 +111,24 @@ function TrashIcon(_handle: Handle) {
 	)
 }
 
+const transactionModalCssVariables = [
+	'--color-primary',
+	'--color-primary-hover',
+	'--color-primary-active',
+	'--color-on-primary',
+	'--color-primary-text',
+	'--color-surface',
+	'--color-text',
+	'--color-text-muted',
+	'--color-border',
+	'--font-family',
+	'--font-size-sm',
+	'--font-size-base',
+	'--font-size-lg',
+] as const
+
+const transactionModalCssFontExample = `--font-family: "Comic Sans MS", "Comic Sans", cursive;`
+
 type SettingsState =
 	| { status: 'loading' | 'error'; message: string; kids: Array<KidSummary> }
 	| {
@@ -143,6 +161,11 @@ export function SettingsRoute(handle: Handle) {
 	let newKidName = ''
 	let newKidEmoji: string = getRandomDefaultKidEmoji()
 	let newAccountColorsByKidId: Record<number, string> = {}
+	let editingKidTransactionModalCss: { kidId: number; kidName: string } | null =
+		null
+	let transactionModalCssDraft = ''
+	let transactionModalCssSaveError: string | null = null
+	let transactionModalCssSaving = false
 
 	async function refreshSettings() {
 		const hadReadyData = state.status === 'ready'
@@ -254,6 +277,54 @@ export function SettingsRoute(handle: Handle) {
 			window.requestAnimationFrame(tryFocus)
 		}
 		window.requestAnimationFrame(tryFocus)
+	}
+
+	function openTransactionModalCssEditor(kid: KidSummary) {
+		editingKidTransactionModalCss = { kidId: kid.id, kidName: kid.name }
+		transactionModalCssDraft = kid.transactionModalCss
+		transactionModalCssSaveError = null
+		transactionModalCssSaving = false
+		handle.update()
+	}
+
+	function closeTransactionModalCssEditor() {
+		if (transactionModalCssSaving) return
+		editingKidTransactionModalCss = null
+		transactionModalCssDraft = ''
+		transactionModalCssSaveError = null
+		handle.update()
+	}
+
+	async function saveTransactionModalCss() {
+		if (state.status !== 'ready') return
+		if (!editingKidTransactionModalCss || transactionModalCssSaving) return
+		const { kidId } = editingKidTransactionModalCss
+		const kid = state.kids.find((entry) => entry.id === kidId)
+		if (!kid) return
+		transactionModalCssSaving = true
+		transactionModalCssSaveError = null
+		handle.update()
+		try {
+			await updateKid({
+				kidId: kid.id,
+				name: kid.name,
+				emoji: kid.emoji,
+				transactionModalCss: transactionModalCssDraft,
+			})
+			editingKidTransactionModalCss = null
+			transactionModalCssDraft = ''
+			await refreshSettings()
+			if (state.status === 'ready') {
+				notify(`Saved transaction modal CSS for ${kid.name}.`)
+			}
+		} catch (error) {
+			transactionModalCssSaveError =
+				error instanceof Error
+					? error.message
+					: 'Could not save transaction modal CSS.'
+		}
+		transactionModalCssSaving = false
+		handle.update()
 	}
 
 	async function handleCreateKid() {
@@ -441,6 +512,9 @@ export function SettingsRoute(handle: Handle) {
 										alignItems: 'center',
 										[mq.mobile]: {
 											gridTemplateColumns: 'auto 4rem 1fr auto',
+											'& [data-kid-actions]': {
+												gridColumn: '1 / -1',
+											},
 										},
 									}}
 								>
@@ -537,19 +611,40 @@ export function SettingsRoute(handle: Handle) {
 											fontWeight: typography.fontWeight.bold,
 										}}
 									/>
-									<button
-										type="button"
-										aria-label={`Archive ${kid.name}`}
-										on={{
-											click: async () => {
-												await archiveKid(kid.id)
-												await refreshSettings()
-											},
+									<div
+										data-kid-actions
+										css={{
+											display: 'flex',
+											gap: spacing.xs,
+											flexWrap: 'wrap',
+											justifyContent: 'flex-end',
 										}}
-										css={archiveIconButtonCss}
 									>
-										<TrashIcon />
-									</button>
+										<button
+											type="button"
+											on={{
+												click: () => {
+													openTransactionModalCssEditor(kid)
+												},
+											}}
+											css={buttonCss}
+										>
+											Customize transaction modal
+										</button>
+										<button
+											type="button"
+											aria-label={`Archive ${kid.name}`}
+											on={{
+												click: async () => {
+													await archiveKid(kid.id)
+													await refreshSettings()
+												},
+											}}
+											css={archiveIconButtonCss}
+										>
+											<TrashIcon />
+										</button>
+									</div>
 								</header>
 								<p css={{ margin: 0, color: colors.textMuted }}>
 									Total: {formatCents(kid.totalBalanceCents)}
@@ -1100,6 +1195,172 @@ export function SettingsRoute(handle: Handle) {
 							</a>
 						</div>
 					</section>
+
+					{editingKidTransactionModalCss ? (
+						<div
+							on={{
+								click: (event) => {
+									if (event.target === event.currentTarget) {
+										closeTransactionModalCssEditor()
+									}
+								},
+							}}
+							css={{
+								position: 'fixed',
+								inset: 0,
+								backgroundColor: 'rgba(0, 0, 0, 0.45)',
+								display: 'grid',
+								placeItems: 'center',
+								padding: spacing.md,
+								zIndex: 1000,
+							}}
+						>
+							<section
+								role="dialog"
+								aria-modal="true"
+								aria-labelledby="kid-transaction-modal-css-title"
+								on={{
+									keydown: (event) => {
+										if (event.key === 'Escape') {
+											event.preventDefault()
+											closeTransactionModalCssEditor()
+										}
+									},
+								}}
+								css={{
+									width: 'min(42rem, 100%)',
+									maxHeight: '85dvh',
+									overflow: 'auto',
+									display: 'grid',
+									gap: spacing.md,
+									padding: spacing.lg,
+									borderRadius: radius.xl,
+									border: `3px solid ${colors.border}`,
+									backgroundColor: colors.surface,
+									boxShadow: shadows.lg,
+								}}
+							>
+								<header
+									css={{ display: 'flex', justifyContent: 'space-between' }}
+								>
+									<div css={{ display: 'grid', gap: spacing.xs }}>
+										<h3
+											id="kid-transaction-modal-css-title"
+											css={{ margin: 0, color: colors.text }}
+										>
+											Customize {editingKidTransactionModalCss.kidName}&apos;s
+											transaction modal
+										</h3>
+										<p css={{ margin: 0, color: colors.textMuted }}>
+											Enter CSS declarations. These only apply while this
+											kid&apos;s transaction modal is open.
+										</p>
+									</div>
+									<button
+										type="button"
+										on={{ click: closeTransactionModalCssEditor }}
+										css={buttonCss}
+										disabled={transactionModalCssSaving}
+									>
+										Close
+									</button>
+								</header>
+								<div css={{ display: 'grid', gap: spacing.xs }}>
+									<strong css={{ color: colors.text }}>
+										Supported CSS variables
+									</strong>
+									<ul
+										css={{
+											margin: 0,
+											paddingLeft: spacing.lg,
+											color: colors.textMuted,
+											display: 'grid',
+											gap: 2,
+										}}
+									>
+										{transactionModalCssVariables.map((cssVariable) => (
+											<li key={cssVariable}>
+												<code>{cssVariable}</code>
+											</li>
+										))}
+									</ul>
+								</div>
+								<div css={{ display: 'grid', gap: spacing.xs }}>
+									<strong css={{ color: colors.text }}>Font example</strong>
+									<pre
+										css={{
+											margin: 0,
+											padding: spacing.sm,
+											borderRadius: radius.md,
+											border: `2px solid ${colors.border}`,
+											backgroundColor: colors.primarySoftest,
+											color: colors.text,
+											overflowX: 'auto',
+										}}
+									>
+										{transactionModalCssFontExample}
+									</pre>
+								</div>
+								<label css={{ display: 'grid', gap: spacing.xs }}>
+									<span css={{ color: colors.text }}>
+										Custom CSS declarations
+									</span>
+									<textarea
+										value={transactionModalCssDraft}
+										on={{
+											input: (event) => {
+												if (
+													!(event.currentTarget instanceof HTMLTextAreaElement)
+												)
+													return
+												transactionModalCssDraft = event.currentTarget.value
+												transactionModalCssSaveError = null
+												handle.update()
+											},
+										}}
+										rows={10}
+										css={{
+											...inputCss,
+											fontFamily:
+												'ui-monospace, SFMono-Regular, Menlo, monospace',
+											resize: 'vertical',
+											minHeight: '12rem',
+										}}
+									/>
+								</label>
+								{transactionModalCssSaveError ? (
+									<p css={{ margin: 0, color: colors.error }}>
+										{transactionModalCssSaveError}
+									</p>
+								) : null}
+								<div
+									css={{
+										display: 'flex',
+										justifyContent: 'flex-end',
+										gap: spacing.sm,
+										flexWrap: 'wrap',
+									}}
+								>
+									<button
+										type="button"
+										on={{ click: closeTransactionModalCssEditor }}
+										css={buttonCss}
+										disabled={transactionModalCssSaving}
+									>
+										Cancel
+									</button>
+									<button
+										type="button"
+										on={{ click: () => void saveTransactionModalCss() }}
+										css={buttonCss}
+										disabled={transactionModalCssSaving}
+									>
+										{transactionModalCssSaving ? 'Saving...' : 'Save CSS'}
+									</button>
+								</div>
+							</section>
+						</div>
+					) : null}
 
 					{state.message ? (
 						<p

--- a/client/routes/settings.tsx
+++ b/client/routes/settings.tsx
@@ -89,6 +89,16 @@ function moveItem<T>(items: Array<T>, from: number, to: number) {
 	return nextItems
 }
 
+function getFocusableElements(container: HTMLElement) {
+	const selector =
+		'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+	const candidates = Array.from(container.querySelectorAll(selector))
+	return candidates.filter(
+		(element): element is HTMLElement =>
+			element instanceof HTMLElement && element.tabIndex >= 0,
+	)
+}
+
 type ReorderDirection = 'up' | 'down'
 
 function TrashIcon(_handle: Handle) {
@@ -174,6 +184,7 @@ export function SettingsRoute(handle: Handle) {
 	let newAccountColorsByKidId: Record<number, string> = {}
 	let editingKidTransactionModalCss: { kidId: number; kidName: string } | null =
 		null
+	let transactionModalCssOpener: HTMLElement | null = null
 	let transactionModalCssDraft = ''
 	let transactionModalCssSaveError: string | null = null
 	let transactionModalCssSaving = false
@@ -316,6 +327,13 @@ export function SettingsRoute(handle: Handle) {
 	function openTransactionModalCssEditor(kid: KidSummary) {
 		clearCloseTransactionModalCssTimeout()
 		removeTransactionModalPreviewStyles()
+		if (typeof document === 'undefined') {
+			transactionModalCssOpener = null
+		} else {
+			const activeElement = document.activeElement
+			transactionModalCssOpener =
+				activeElement instanceof HTMLElement ? activeElement : null
+		}
 		editingKidTransactionModalCss = { kidId: kid.id, kidName: kid.name }
 		transactionModalCssDraft = kid.transactionModalCss
 		transactionModalCssSaveError = null
@@ -339,6 +357,8 @@ export function SettingsRoute(handle: Handle) {
 			transactionModalCssClosing
 		)
 			return
+		const opener = transactionModalCssOpener
+		transactionModalCssOpener = null
 		transactionModalCssClosing = true
 		handle.update()
 		closeTransactionModalCssTimeoutId = window.setTimeout(() => {
@@ -349,7 +369,50 @@ export function SettingsRoute(handle: Handle) {
 			closeTransactionModalCssTimeoutId = null
 			removeTransactionModalPreviewStyles()
 			handle.update()
+			if (opener?.isConnected) {
+				handle.queueTask(() => {
+					opener.focus()
+				})
+			}
 		}, modalCloseAnimationDurationMs)
+	}
+
+	function handleTransactionModalCssKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			event.preventDefault()
+			closeTransactionModalCssEditor()
+			return
+		}
+
+		if (event.key !== 'Tab') return
+		if (!(event.currentTarget instanceof HTMLElement)) return
+
+		const focusableElements = getFocusableElements(event.currentTarget)
+		if (focusableElements.length === 0) {
+			event.preventDefault()
+			return
+		}
+
+		const activeElement = document.activeElement
+		const firstFocusableElement = focusableElements[0]
+		const lastFocusableElement = focusableElements[focusableElements.length - 1]
+		if (!firstFocusableElement || !lastFocusableElement) return
+		const activeInModal = focusableElements.includes(
+			activeElement as HTMLElement,
+		)
+
+		if (event.shiftKey) {
+			if (activeElement === firstFocusableElement || !activeInModal) {
+				event.preventDefault()
+				lastFocusableElement.focus()
+			}
+			return
+		}
+
+		if (activeElement === lastFocusableElement || !activeInModal) {
+			event.preventDefault()
+			firstFocusableElement.focus()
+		}
 	}
 
 	async function saveTransactionModalCss() {
@@ -369,13 +432,20 @@ export function SettingsRoute(handle: Handle) {
 				transactionModalCss: transactionModalCssDraft,
 			})
 			clearCloseTransactionModalCssTimeout()
+			const opener = transactionModalCssOpener
 			editingKidTransactionModalCss = null
 			transactionModalCssDraft = ''
 			transactionModalCssClosing = false
+			transactionModalCssOpener = null
 			removeTransactionModalPreviewStyles()
 			await refreshSettings()
 			if (state.status === 'ready') {
 				notify(`Saved transaction modal CSS for ${kid.name}.`)
+			}
+			if (opener?.isConnected) {
+				handle.queueTask(() => {
+					opener.focus()
+				})
 			}
 		} catch (error) {
 			transactionModalCssSaveError =
@@ -1289,14 +1359,7 @@ export function SettingsRoute(handle: Handle) {
 								role="dialog"
 								aria-modal="true"
 								aria-labelledby="kid-transaction-modal-css-title"
-								on={{
-									keydown: (event) => {
-										if (event.key === 'Escape') {
-											event.preventDefault()
-											closeTransactionModalCssEditor()
-										}
-									},
-								}}
+								on={{ keydown: handleTransactionModalCssKeydown }}
 								css={{
 									width: 'min(42rem, 100%)',
 									maxHeight: '85dvh',

--- a/client/routes/settings.tsx
+++ b/client/routes/settings.tsx
@@ -32,6 +32,7 @@ import {
 import { inputCss, buttonCss } from '#client/styles/form-controls.ts'
 import { buildTransactionModalCss } from '#client/styles/transaction-modal-css.ts'
 import { transactionModalCssVariables } from '#shared/transaction-modal-css.ts'
+import { getFocusableElements } from '#client/dom-utils.ts'
 
 const defaultKidEmojis = [
 	'🧒',
@@ -87,16 +88,6 @@ function moveItem<T>(items: Array<T>, from: number, to: number) {
 	const nextItems = [...items]
 	nextItems.splice(to, 0, nextItems.splice(from, 1)[0]!)
 	return nextItems
-}
-
-function getFocusableElements(container: HTMLElement) {
-	const selector =
-		'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-	const candidates = Array.from(container.querySelectorAll(selector))
-	return candidates.filter(
-		(element): element is HTMLElement =>
-			element instanceof HTMLElement && element.tabIndex >= 0,
-	)
 }
 
 type ReorderDirection = 'up' | 'down'

--- a/client/routes/settings.tsx
+++ b/client/routes/settings.tsx
@@ -112,6 +112,25 @@ function TrashIcon(_handle: Handle) {
 	)
 }
 
+function PaintbrushIcon(_handle: Handle) {
+	return () => (
+		<svg
+			viewBox="0 0 24 24"
+			width="18"
+			height="18"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<circle cx="12" cy="12" r="3" />
+			<path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.08a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.08a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+		</svg>
+	)
+}
+
 const transactionModalCssVariables = [
 	'--color-primary',
 	'--color-primary-hover',
@@ -134,6 +153,7 @@ const transactionModalCssGoogleFontExample = `@import url("https://fonts.googlea
 :root {
 	--font-family: "MedievalSharp", cursive;
 }`
+const modalCloseAnimationDurationMs = 220
 
 type SettingsState =
 	| { status: 'loading' | 'error'; message: string; kids: Array<KidSummary> }
@@ -172,6 +192,23 @@ export function SettingsRoute(handle: Handle) {
 	let transactionModalCssDraft = ''
 	let transactionModalCssSaveError: string | null = null
 	let transactionModalCssSaving = false
+	let transactionModalCssClosing = false
+	let closeTransactionModalCssTimeoutId: number | null = null
+
+	function removeTransactionModalPreviewStyles() {
+		if (typeof document === 'undefined') return
+		for (const element of document.querySelectorAll(
+			'style[data-kid-transaction-modal-preview-css]',
+		)) {
+			element.remove()
+		}
+	}
+
+	function clearCloseTransactionModalCssTimeout() {
+		if (closeTransactionModalCssTimeoutId === null) return
+		window.clearTimeout(closeTransactionModalCssTimeoutId)
+		closeTransactionModalCssTimeoutId = null
+	}
 
 	async function refreshSettings() {
 		const hadReadyData = state.status === 'ready'
@@ -208,6 +245,12 @@ export function SettingsRoute(handle: Handle) {
 
 	handle.queueTask(async () => {
 		await refreshSettings()
+	})
+	handle.queueTask(() => {
+		return () => {
+			clearCloseTransactionModalCssTimeout()
+			removeTransactionModalPreviewStyles()
+		}
 	})
 
 	function notify(message: string) {
@@ -286,19 +329,42 @@ export function SettingsRoute(handle: Handle) {
 	}
 
 	function openTransactionModalCssEditor(kid: KidSummary) {
+		clearCloseTransactionModalCssTimeout()
+		removeTransactionModalPreviewStyles()
 		editingKidTransactionModalCss = { kidId: kid.id, kidName: kid.name }
 		transactionModalCssDraft = kid.transactionModalCss
 		transactionModalCssSaveError = null
 		transactionModalCssSaving = false
+		transactionModalCssClosing = false
 		handle.update()
+		handle.queueTask(() => {
+			const cssInput = document.getElementById(
+				'kid-transaction-modal-css-input',
+			)
+			if (cssInput instanceof HTMLTextAreaElement) {
+				cssInput.focus()
+			}
+		})
 	}
 
 	function closeTransactionModalCssEditor() {
-		if (transactionModalCssSaving) return
-		editingKidTransactionModalCss = null
-		transactionModalCssDraft = ''
-		transactionModalCssSaveError = null
+		if (
+			transactionModalCssSaving ||
+			!editingKidTransactionModalCss ||
+			transactionModalCssClosing
+		)
+			return
+		transactionModalCssClosing = true
 		handle.update()
+		closeTransactionModalCssTimeoutId = window.setTimeout(() => {
+			editingKidTransactionModalCss = null
+			transactionModalCssDraft = ''
+			transactionModalCssSaveError = null
+			transactionModalCssClosing = false
+			closeTransactionModalCssTimeoutId = null
+			removeTransactionModalPreviewStyles()
+			handle.update()
+		}, modalCloseAnimationDurationMs)
 	}
 
 	async function saveTransactionModalCss() {
@@ -317,8 +383,11 @@ export function SettingsRoute(handle: Handle) {
 				emoji: kid.emoji,
 				transactionModalCss: transactionModalCssDraft,
 			})
+			clearCloseTransactionModalCssTimeout()
 			editingKidTransactionModalCss = null
 			transactionModalCssDraft = ''
+			transactionModalCssClosing = false
+			removeTransactionModalPreviewStyles()
 			await refreshSettings()
 			if (state.status === 'ready') {
 				notify(`Saved transaction modal CSS for ${kid.name}.`)
@@ -628,14 +697,16 @@ export function SettingsRoute(handle: Handle) {
 									>
 										<button
 											type="button"
+											aria-label={`Customize ${kid.name}'s transaction modal`}
+											title="Customize transaction modal"
 											on={{
 												click: () => {
 													openTransactionModalCssEditor(kid)
 												},
 											}}
-											css={buttonCss}
+											css={transactionModalIconButtonCss}
 										>
-											Customize transaction modal
+											<PaintbrushIcon />
 										</button>
 										<button
 											type="button"
@@ -1219,6 +1290,14 @@ export function SettingsRoute(handle: Handle) {
 								placeItems: 'center',
 								padding: spacing.md,
 								zIndex: 1000,
+								pointerEvents: transactionModalCssClosing ? 'none' : 'auto',
+								animation: transactionModalCssClosing
+									? `modal-backdrop-out ${modalCloseAnimationDurationMs}ms ease-in forwards`
+									: 'modal-backdrop-in 180ms ease-out forwards',
+								[mq.mobile]: {
+									padding: 0,
+									placeItems: 'stretch',
+								},
 							}}
 						>
 							<section
@@ -1244,6 +1323,18 @@ export function SettingsRoute(handle: Handle) {
 									border: `3px solid ${colors.border}`,
 									backgroundColor: colors.surface,
 									boxShadow: shadows.lg,
+									animation: transactionModalCssClosing
+										? `modal-close ${modalCloseAnimationDurationMs}ms ease-in forwards`
+										: 'modal-pop 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards',
+									[mq.mobile]: {
+										width: '100%',
+										maxHeight: '100dvh',
+										minHeight: '100dvh',
+										borderRadius: 0,
+										border: 'none',
+										gap: spacing.sm,
+										padding: spacing.md,
+									},
 								}}
 							>
 								<header
@@ -1278,7 +1369,7 @@ export function SettingsRoute(handle: Handle) {
 										Updates in real time as you type.
 									</p>
 									{transactionModalCssDraft.trim() ? (
-										<style>
+										<style data-kid-transaction-modal-preview-css>
 											{buildTransactionModalCss(transactionModalCssDraft)}
 										</style>
 									) : null}
@@ -1337,6 +1428,7 @@ export function SettingsRoute(handle: Handle) {
 										Custom CSS declarations
 									</span>
 									<textarea
+										id="kid-transaction-modal-css-input"
 										value={transactionModalCssDraft}
 										on={{
 											input: (event) => {
@@ -1484,6 +1576,17 @@ const dangerButtonCss = {
 
 const archiveIconButtonCss = {
 	...dangerButtonCss,
+	minHeight: 40,
+	minWidth: 40,
+	padding: 0,
+	lineHeight: 1,
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+}
+
+const transactionModalIconButtonCss = {
+	...buttonCss,
 	minHeight: 40,
 	minWidth: 40,
 	padding: 0,

--- a/client/routes/settings.tsx
+++ b/client/routes/settings.tsx
@@ -32,7 +32,7 @@ import {
 import { inputCss, buttonCss } from '#client/styles/form-controls.ts'
 import { buildTransactionModalCss } from '#client/styles/transaction-modal-css.ts'
 import { transactionModalCssVariables } from '#shared/transaction-modal-css.ts'
-import { getFocusableElements } from '#client/dom-utils.ts'
+import { handleModalKeydown } from '#client/dom-utils.ts'
 
 const defaultKidEmojis = [
 	'🧒',
@@ -369,41 +369,7 @@ export function SettingsRoute(handle: Handle) {
 	}
 
 	function handleTransactionModalCssKeydown(event: KeyboardEvent) {
-		if (event.key === 'Escape') {
-			event.preventDefault()
-			closeTransactionModalCssEditor()
-			return
-		}
-
-		if (event.key !== 'Tab') return
-		if (!(event.currentTarget instanceof HTMLElement)) return
-
-		const focusableElements = getFocusableElements(event.currentTarget)
-		if (focusableElements.length === 0) {
-			event.preventDefault()
-			return
-		}
-
-		const activeElement = document.activeElement
-		const firstFocusableElement = focusableElements[0]
-		const lastFocusableElement = focusableElements[focusableElements.length - 1]
-		if (!firstFocusableElement || !lastFocusableElement) return
-		const activeInModal = focusableElements.includes(
-			activeElement as HTMLElement,
-		)
-
-		if (event.shiftKey) {
-			if (activeElement === firstFocusableElement || !activeInModal) {
-				event.preventDefault()
-				lastFocusableElement.focus()
-			}
-			return
-		}
-
-		if (activeElement === lastFocusableElement || !activeInModal) {
-			event.preventDefault()
-			firstFocusableElement.focus()
-		}
+		handleModalKeydown(event, closeTransactionModalCssEditor)
 	}
 
 	async function saveTransactionModalCss() {

--- a/client/routes/settings.tsx
+++ b/client/routes/settings.tsx
@@ -113,7 +113,7 @@ function TrashIcon(_handle: Handle) {
 	)
 }
 
-function PaintbrushIcon(_handle: Handle) {
+function SettingsIcon(_handle: Handle) {
 	return () => (
 		<svg
 			viewBox="0 0 24 24"
@@ -691,7 +691,7 @@ export function SettingsRoute(handle: Handle) {
 											}}
 											css={transactionModalIconButtonCss}
 										>
-											<PaintbrushIcon />
+											<SettingsIcon />
 										</button>
 										<button
 											type="button"

--- a/client/routes/settings.tsx
+++ b/client/routes/settings.tsx
@@ -129,6 +129,12 @@ const transactionModalCssVariables = [
 
 const transactionModalCssFontExample = `--font-family: "Comic Sans MS", "Comic Sans", cursive;`
 
+function buildTransactionModalPreviewCss(transactionModalCss: string) {
+	const trimmed = transactionModalCss.trim()
+	if (!trimmed) return ''
+	return `[data-kid-transaction-modal-preview] {\n${trimmed}\n}`
+}
+
 type SettingsState =
 	| { status: 'loading' | 'error'; message: string; kids: Array<KidSummary> }
 	| {
@@ -1265,42 +1271,68 @@ export function SettingsRoute(handle: Handle) {
 										Close
 									</button>
 								</header>
-								<div css={{ display: 'grid', gap: spacing.xs }}>
-									<strong css={{ color: colors.text }}>
-										Supported CSS variables
-									</strong>
-									<ul
+								<section css={{ display: 'grid', gap: spacing.sm }}>
+									<strong css={{ color: colors.text }}>Live preview</strong>
+									<p css={{ margin: 0, color: colors.textMuted }}>
+										Updates in real time as you type.
+									</p>
+									{transactionModalCssDraft.trim() ? (
+										<style>
+											{buildTransactionModalPreviewCss(
+												transactionModalCssDraft,
+											)}
+										</style>
+									) : null}
+									<section
+										data-kid-transaction-modal-preview
 										css={{
-											margin: 0,
-											paddingLeft: spacing.lg,
-											color: colors.textMuted,
+											width: 'min(30rem, 100%)',
 											display: 'grid',
-											gap: 2,
+											gap: spacing.md,
+											padding: spacing.md,
+											fontFamily: 'var(--font-family)',
+											borderRadius: radius.xl,
+											border: `3px solid ${colors.border}`,
+											backgroundColor: colors.surface,
+											boxShadow: shadows.lg,
 										}}
 									>
-										{transactionModalCssVariables.map((cssVariable) => (
-											<li key={cssVariable}>
-												<code>{cssVariable}</code>
-											</li>
-										))}
-									</ul>
-								</div>
-								<div css={{ display: 'grid', gap: spacing.xs }}>
-									<strong css={{ color: colors.text }}>Font example</strong>
-									<pre
-										css={{
-											margin: 0,
-											padding: spacing.sm,
-											borderRadius: radius.md,
-											border: `2px solid ${colors.border}`,
-											backgroundColor: colors.primarySoftest,
-											color: colors.text,
-											overflowX: 'auto',
-										}}
-									>
-										{transactionModalCssFontExample}
-									</pre>
-								</div>
+										<header
+											css={{ display: 'flex', justifyContent: 'space-between' }}
+										>
+											<div>
+												<h3 css={{ margin: 0, color: colors.text }}>
+													{editingKidTransactionModalCss.kidName}
+												</h3>
+												<p css={{ margin: 0, color: colors.textMuted }}>
+													Spending · $12.50
+												</p>
+											</div>
+											<span css={{ color: colors.textMuted }}>Close</span>
+										</header>
+										<label css={{ display: 'grid', gap: spacing.xs }}>
+											<span css={{ color: colors.text }}>Amount</span>
+											<input type="text" value="5.00" readOnly css={inputCss} />
+										</label>
+										<div
+											css={{
+												display: 'grid',
+												gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+												gap: spacing.xs,
+											}}
+										>
+											<button type="button" css={buttonCss}>
+												$1.00
+											</button>
+											<button type="button" css={buttonCss}>
+												$5.00
+											</button>
+											<button type="button" css={buttonCss}>
+												$10.00
+											</button>
+										</div>
+									</section>
+								</section>
 								<label css={{ display: 'grid', gap: spacing.xs }}>
 									<span css={{ color: colors.text }}>
 										Custom CSS declarations
@@ -1318,16 +1350,58 @@ export function SettingsRoute(handle: Handle) {
 												handle.update()
 											},
 										}}
-										rows={10}
+										rows={6}
 										css={{
 											...inputCss,
 											fontFamily:
 												'ui-monospace, SFMono-Regular, Menlo, monospace',
 											resize: 'vertical',
-											minHeight: '12rem',
+											minHeight: '8rem',
 										}}
 									/>
 								</label>
+								<section css={{ display: 'grid', gap: spacing.xs }}>
+									<strong css={{ color: colors.text }}>
+										Supported CSS variables
+									</strong>
+									<div
+										css={{
+											display: 'flex',
+											flexWrap: 'wrap',
+											gap: spacing.xs,
+										}}
+									>
+										{transactionModalCssVariables.map((cssVariable) => (
+											<code
+												key={cssVariable}
+												css={{
+													padding: `${spacing.xs} ${spacing.sm}`,
+													border: `1px solid ${colors.border}`,
+													borderRadius: radius.full,
+													backgroundColor: colors.primarySoftest,
+												}}
+											>
+												{cssVariable}
+											</code>
+										))}
+									</div>
+								</section>
+								<div css={{ display: 'grid', gap: spacing.xs }}>
+									<strong css={{ color: colors.text }}>Font example</strong>
+									<pre
+										css={{
+											margin: 0,
+											padding: spacing.sm,
+											borderRadius: radius.md,
+											border: `2px solid ${colors.border}`,
+											backgroundColor: colors.primarySoftest,
+											color: colors.text,
+											overflowX: 'auto',
+										}}
+									>
+										{transactionModalCssFontExample}
+									</pre>
+								</div>
 								{transactionModalCssSaveError ? (
 									<p css={{ margin: 0, color: colors.error }}>
 										{transactionModalCssSaveError}

--- a/client/routes/settings.tsx
+++ b/client/routes/settings.tsx
@@ -30,6 +30,7 @@ import {
 	mq,
 } from '#client/styles/tokens.ts'
 import { inputCss, buttonCss } from '#client/styles/form-controls.ts'
+import { buildTransactionModalCss } from '#client/styles/transaction-modal-css.ts'
 
 const defaultKidEmojis = [
 	'🧒',
@@ -133,17 +134,6 @@ const transactionModalCssGoogleFontExample = `@import url("https://fonts.googlea
 :root {
 	--font-family: "MedievalSharp", cursive;
 }`
-
-function buildTransactionModalPreviewCss(transactionModalCss: string) {
-	const trimmed = transactionModalCss.trim()
-	if (!trimmed) return ''
-	if (isLikelyCssStylesheet(trimmed)) return trimmed
-	return `:root {\n${trimmed}\n}`
-}
-
-function isLikelyCssStylesheet(cssText: string) {
-	return cssText.includes('{') || cssText.includes('@')
-}
 
 type SettingsState =
 	| { status: 'loading' | 'error'; message: string; kids: Array<KidSummary> }
@@ -1289,9 +1279,7 @@ export function SettingsRoute(handle: Handle) {
 									</p>
 									{transactionModalCssDraft.trim() ? (
 										<style>
-											{buildTransactionModalPreviewCss(
-												transactionModalCssDraft,
-											)}
+											{buildTransactionModalCss(transactionModalCssDraft)}
 										</style>
 									) : null}
 									<section

--- a/client/routes/settings.tsx
+++ b/client/routes/settings.tsx
@@ -31,6 +31,7 @@ import {
 } from '#client/styles/tokens.ts'
 import { inputCss, buttonCss } from '#client/styles/form-controls.ts'
 import { buildTransactionModalCss } from '#client/styles/transaction-modal-css.ts'
+import { transactionModalCssVariables } from '#shared/transaction-modal-css.ts'
 
 const defaultKidEmojis = [
 	'🧒',
@@ -130,22 +131,6 @@ function PaintbrushIcon(_handle: Handle) {
 		</svg>
 	)
 }
-
-const transactionModalCssVariables = [
-	'--color-primary',
-	'--color-primary-hover',
-	'--color-primary-active',
-	'--color-on-primary',
-	'--color-primary-text',
-	'--color-surface',
-	'--color-text',
-	'--color-text-muted',
-	'--color-border',
-	'--font-family',
-	'--font-size-sm',
-	'--font-size-base',
-	'--font-size-lg',
-] as const
 
 const transactionModalCssFontExample = `--font-family: "Comic Sans MS", "Comic Sans", cursive;`
 const transactionModalCssGoogleFontExample = `@import url("https://fonts.googleapis.com/css2?family=MedievalSharp&display=swap");

--- a/client/styles/transaction-modal-css.ts
+++ b/client/styles/transaction-modal-css.ts
@@ -75,6 +75,7 @@ function isLikelyCssStylesheet(cssText: string) {
 export function buildTransactionModalCss(transactionModalCss: string) {
 	const trimmed = transactionModalCss.trim()
 	if (!trimmed) return ''
-	if (isLikelyCssStylesheet(trimmed)) return trimmed
-	return `:root {\n${trimmed}\n}`
+	const sanitized = trimmed.replace(/<\/style/gi, '<\\/style')
+	if (isLikelyCssStylesheet(sanitized)) return sanitized
+	return `:root {\n${sanitized}\n}`
 }

--- a/client/styles/transaction-modal-css.ts
+++ b/client/styles/transaction-modal-css.ts
@@ -2,6 +2,7 @@ function isLikelyCssStylesheet(cssText: string) {
 	let inSingleQuote = false
 	let inDoubleQuote = false
 	let inComment = false
+	let hasStatementText = false
 
 	for (let index = 0; index < cssText.length; index += 1) {
 		const char = cssText[index]
@@ -53,7 +54,19 @@ function isLikelyCssStylesheet(cssText: string) {
 			continue
 		}
 
-		if (char === '{' || char === '@') return true
+		if (char === ';' || char === '}') {
+			hasStatementText = false
+			continue
+		}
+
+		if (char === '{') return true
+
+		if (!hasStatementText) {
+			if (char === '@') return true
+			if (char?.trim()) {
+				hasStatementText = true
+			}
+		}
 	}
 
 	return false

--- a/client/styles/transaction-modal-css.ts
+++ b/client/styles/transaction-modal-css.ts
@@ -1,5 +1,62 @@
 function isLikelyCssStylesheet(cssText: string) {
-	return cssText.includes('{') || cssText.includes('@')
+	let inSingleQuote = false
+	let inDoubleQuote = false
+	let inComment = false
+
+	for (let index = 0; index < cssText.length; index += 1) {
+		const char = cssText[index]
+		const next = cssText[index + 1]
+
+		if (inComment) {
+			if (char === '*' && next === '/') {
+				inComment = false
+				index += 1
+			}
+			continue
+		}
+
+		if (inSingleQuote) {
+			if (char === '\\') {
+				index += 1
+				continue
+			}
+			if (char === "'") {
+				inSingleQuote = false
+			}
+			continue
+		}
+
+		if (inDoubleQuote) {
+			if (char === '\\') {
+				index += 1
+				continue
+			}
+			if (char === '"') {
+				inDoubleQuote = false
+			}
+			continue
+		}
+
+		if (char === '/' && next === '*') {
+			inComment = true
+			index += 1
+			continue
+		}
+
+		if (char === "'") {
+			inSingleQuote = true
+			continue
+		}
+
+		if (char === '"') {
+			inDoubleQuote = true
+			continue
+		}
+
+		if (char === '{' || char === '@') return true
+	}
+
+	return false
 }
 
 export function buildTransactionModalCss(transactionModalCss: string) {

--- a/client/styles/transaction-modal-css.ts
+++ b/client/styles/transaction-modal-css.ts
@@ -1,0 +1,10 @@
+function isLikelyCssStylesheet(cssText: string) {
+	return cssText.includes('{') || cssText.includes('@')
+}
+
+export function buildTransactionModalCss(transactionModalCss: string) {
+	const trimmed = transactionModalCss.trim()
+	if (!trimmed) return ''
+	if (isLikelyCssStylesheet(trimmed)) return trimmed
+	return `:root {\n${trimmed}\n}`
+}

--- a/docs/agents/setup.md
+++ b/docs/agents/setup.md
@@ -42,8 +42,9 @@ After `bun run dev` is running and you are logged in:
 - `/` should render the main ledger board with family total and account cards.
 - `/settings` should allow creating kids/accounts and managing archive/delete.
 - `/settings` kid cards should allow saving per-kid transaction modal CSS
-  declarations (for example `--font-family`) and `/` should apply them only
-  while that kid's transaction modal is open.
+  declarations (for example `--font-family`), show a live in-modal preview while
+  editing, and `/` should apply saved CSS only while that kid's transaction
+  modal is open.
 - `/history` should show recent-first transactions and URL-synced filters.
 - `/ledger/export/json` should download a JSON backup while authenticated.
 

--- a/docs/agents/setup.md
+++ b/docs/agents/setup.md
@@ -42,9 +42,9 @@ After `bun run dev` is running and you are logged in:
 - `/` should render the main ledger board with family total and account cards.
 - `/settings` should allow creating kids/accounts and managing archive/delete.
 - `/settings` kid cards should allow saving per-kid transaction modal CSS
-  declarations (for example `--font-family`), show a live in-modal preview while
-  editing, and `/` should apply saved CSS only while that kid's transaction
-  modal is open.
+  declarations/rules (including optional `@import` font rules), show a live
+  in-modal preview while editing, and `/` should apply saved CSS to the page
+  only while that kid's transaction modal is open.
 - `/history` should show recent-first transactions and URL-synced filters.
 - `/ledger/export/json` should download a JSON backup while authenticated.
 

--- a/docs/agents/setup.md
+++ b/docs/agents/setup.md
@@ -41,6 +41,9 @@ After `bun run dev` is running and you are logged in:
 
 - `/` should render the main ledger board with family total and account cards.
 - `/settings` should allow creating kids/accounts and managing archive/delete.
+- `/settings` kid cards should allow saving per-kid transaction modal CSS
+  declarations (for example `--font-family`) and `/` should apply them only
+  while that kid's transaction modal is open.
 - `/history` should show recent-first transactions and URL-synced filters.
 - `/ledger/export/json` should download a JSON backup while authenticated.
 

--- a/e2e/kid-transaction-modal-css.spec.ts
+++ b/e2e/kid-transaction-modal-css.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from './playwright-utils.ts'
+
+test('kid transaction modal custom css applies only while open', async ({
+	page,
+	login,
+}) => {
+	const kidName = `Kid-${crypto.randomUUID().slice(0, 6)}`
+	const accountName = `Spending-${crypto.randomUUID().slice(0, 6)}`
+
+	await login()
+	await page.goto('/settings')
+
+	await page.getByPlaceholder('Kid name').fill(kidName)
+	await page.getByRole('button', { name: 'Add' }).first().click()
+
+	const kidNameInput = page.getByRole('textbox', { name: `${kidName} name` })
+	await expect(kidNameInput).toBeVisible()
+	const kidCard = page.locator('article').filter({ has: kidNameInput }).first()
+	await kidCard.getByPlaceholder('New account name').fill(accountName)
+	await kidCard.getByRole('button', { name: 'Add account' }).click()
+
+	await kidCard
+		.getByRole('button', { name: 'Customize transaction modal' })
+		.click()
+
+	const customizationDialog = page.getByRole('dialog')
+	await expect(customizationDialog).toBeVisible()
+	await customizationDialog
+		.getByRole('textbox', { name: 'Custom CSS declarations' })
+		.fill(
+			[
+				'--font-family: "Courier New", monospace;',
+				'--color-surface: #fff7dd;',
+				'--color-border: #f59e0b;',
+			].join('\n'),
+		)
+	await customizationDialog.getByRole('button', { name: 'Save CSS' }).click()
+	await expect(customizationDialog).toBeHidden()
+
+	await page.goto('/')
+	await page.getByRole('button', { name: new RegExp(accountName) }).click()
+	const transactionDialog = page.getByRole('dialog')
+	await expect(transactionDialog).toBeVisible()
+
+	const fontFamily = await transactionDialog.evaluate((element) =>
+		window.getComputedStyle(element).fontFamily.toLowerCase(),
+	)
+	expect(fontFamily).toContain('courier new')
+
+	const customStyleTagCountWhileOpen = await page
+		.locator('style[data-kid-transaction-modal-css]')
+		.count()
+	expect(customStyleTagCountWhileOpen).toBe(1)
+
+	await transactionDialog.getByRole('button', { name: 'Close' }).click()
+	await expect(transactionDialog).toBeHidden()
+
+	await expect
+		.poll(async () =>
+			page.locator('style[data-kid-transaction-modal-css]').count(),
+		)
+		.toBe(0)
+})

--- a/e2e/kid-transaction-modal-css.spec.ts
+++ b/e2e/kid-transaction-modal-css.spec.ts
@@ -20,7 +20,7 @@ test('kid transaction modal custom css applies only while open', async ({
 	await kidCard.getByRole('button', { name: 'Add account' }).click()
 
 	await kidCard
-		.getByRole('button', { name: 'Customize transaction modal' })
+		.getByTitle('Customize transaction modal')
 		.click()
 
 	const customizationDialog = page.getByRole('dialog')

--- a/e2e/kid-transaction-modal-css.spec.ts
+++ b/e2e/kid-transaction-modal-css.spec.ts
@@ -9,6 +9,9 @@ test('kid transaction modal custom css applies only while open', async ({
 
 	await login()
 	await page.goto('/settings')
+	const initialBodyBackgroundImage = await page.evaluate(() =>
+		window.getComputedStyle(document.body).backgroundImage.toLowerCase(),
+	)
 
 	await page.getByPlaceholder('Kid name').fill(kidName)
 	await page.getByRole('button', { name: 'Add' }).first().click()
@@ -19,9 +22,7 @@ test('kid transaction modal custom css applies only while open', async ({
 	await kidCard.getByPlaceholder('New account name').fill(accountName)
 	await kidCard.getByRole('button', { name: 'Add account' }).click()
 
-	await kidCard
-		.getByTitle('Customize transaction modal')
-		.click()
+	await kidCard.getByTitle('Customize transaction modal').click()
 
 	const customizationDialog = page.getByRole('dialog')
 	await expect(customizationDialog).toBeVisible()
@@ -83,5 +84,5 @@ test('kid transaction modal custom css applies only while open', async ({
 	const bodyBackgroundImageAfterClose = await page.evaluate(() =>
 		window.getComputedStyle(document.body).backgroundImage.toLowerCase(),
 	)
-	expect(bodyBackgroundImageAfterClose).not.toBe('none')
+	expect(bodyBackgroundImageAfterClose).toBe(initialBodyBackgroundImage)
 })

--- a/e2e/kid-transaction-modal-css.spec.ts
+++ b/e2e/kid-transaction-modal-css.spec.ts
@@ -33,9 +33,15 @@ test('kid transaction modal custom css applies only while open', async ({
 		.getByRole('textbox', { name: 'Custom CSS declarations' })
 		.fill(
 			[
-				'--font-family: "Courier New", monospace;',
-				'--color-surface: #fff7dd;',
-				'--color-border: #f59e0b;',
+				':root {',
+				'	--font-family: "Courier New", monospace;',
+				'	--color-surface: #fff7dd;',
+				'	--color-border: #f59e0b;',
+				'}',
+				'',
+				'body {',
+				'	background-image: none !important;',
+				'}',
 			].join('\n'),
 		)
 
@@ -56,6 +62,10 @@ test('kid transaction modal custom css applies only while open', async ({
 		window.getComputedStyle(element).fontFamily.toLowerCase(),
 	)
 	expect(fontFamily).toContain('courier new')
+	const bodyBackgroundImageWhileOpen = await page.evaluate(() =>
+		window.getComputedStyle(document.body).backgroundImage.toLowerCase(),
+	)
+	expect(bodyBackgroundImageWhileOpen).toBe('none')
 
 	const customStyleTagCountWhileOpen = await page
 		.locator('style[data-kid-transaction-modal-css]')
@@ -70,4 +80,8 @@ test('kid transaction modal custom css applies only while open', async ({
 			page.locator('style[data-kid-transaction-modal-css]').count(),
 		)
 		.toBe(0)
+	const bodyBackgroundImageAfterClose = await page.evaluate(() =>
+		window.getComputedStyle(document.body).backgroundImage.toLowerCase(),
+	)
+	expect(bodyBackgroundImageAfterClose).not.toBe('none')
 })

--- a/e2e/kid-transaction-modal-css.spec.ts
+++ b/e2e/kid-transaction-modal-css.spec.ts
@@ -25,6 +25,10 @@ test('kid transaction modal custom css applies only while open', async ({
 
 	const customizationDialog = page.getByRole('dialog')
 	await expect(customizationDialog).toBeVisible()
+	const livePreview = customizationDialog.locator(
+		'[data-kid-transaction-modal-preview]',
+	)
+	await expect(livePreview).toBeVisible()
 	await customizationDialog
 		.getByRole('textbox', { name: 'Custom CSS declarations' })
 		.fill(
@@ -34,6 +38,12 @@ test('kid transaction modal custom css applies only while open', async ({
 				'--color-border: #f59e0b;',
 			].join('\n'),
 		)
+
+	const livePreviewFontFamily = await livePreview.evaluate((element) =>
+		window.getComputedStyle(element).fontFamily.toLowerCase(),
+	)
+	expect(livePreviewFontFamily).toContain('courier new')
+
 	await customizationDialog.getByRole('button', { name: 'Save CSS' }).click()
 	await expect(customizationDialog).toBeHidden()
 

--- a/mcp/mcp-server-e2e.test.ts
+++ b/mcp/mcp-server-e2e.test.ts
@@ -662,3 +662,58 @@ test(
 	},
 	{ timeout: defaultTimeoutMs },
 )
+
+test(
+	'mcp server supports transaction modal css on kid create and update',
+	async () => {
+		await using database = await createTestDatabase()
+		await using server = await startDevServer(database.persistDir)
+		await using mcpClient = await createMcpClient(server.origin, database.user)
+
+		const createdResult = await mcpClient.client.callTool({
+			name: 'ledger_create_kid',
+			arguments: {
+				name: 'Luna',
+				emoji: '🧙',
+				transactionModalCss: '--color-primary: #7c3aed;',
+			},
+		})
+		const createdStructured = (createdResult as CallToolResult).structuredContent as
+			| { id?: unknown }
+			| undefined
+		const kidId = Number(createdStructured?.id)
+		expect(Number.isInteger(kidId)).toBe(true)
+
+		const updatedCss = '--color-primary: #1d4ed8;'
+		await mcpClient.client.callTool({
+			name: 'ledger_update_kid',
+			arguments: {
+				kidId,
+				name: 'Luna Lovegood',
+				emoji: '🧙',
+				transactionModalCss: updatedCss,
+			},
+		})
+
+		const dashboardResult = await mcpClient.client.callTool({
+			name: 'ledger_get_dashboard',
+			arguments: {},
+		})
+		const dashboardStructured = (dashboardResult as CallToolResult)
+			.structuredContent as
+			| {
+					kids?: Array<{
+						id?: number
+						name?: string
+						transactionModalCss?: string
+					}>
+			  }
+			| undefined
+		const createdKid = dashboardStructured?.kids?.find(
+			(kid) => Number(kid.id) === kidId,
+		)
+		expect(createdKid?.name).toBe('Luna Lovegood')
+		expect(createdKid?.transactionModalCss).toBe(updatedCss)
+	},
+	{ timeout: defaultTimeoutMs },
+)

--- a/mcp/mcp-server-e2e.test.ts
+++ b/mcp/mcp-server-e2e.test.ts
@@ -678,9 +678,8 @@ test(
 				transactionModalCss: '--color-primary: #7c3aed;',
 			},
 		})
-		const createdStructured = (createdResult as CallToolResult).structuredContent as
-			| { id?: unknown }
-			| undefined
+		const createdStructured = (createdResult as CallToolResult)
+			.structuredContent as { id?: unknown } | undefined
 		const kidId = Number(createdStructured?.id)
 		expect(Number.isInteger(kidId)).toBe(true)
 

--- a/mcp/tools/ledger-tools.ts
+++ b/mcp/tools/ledger-tools.ts
@@ -34,11 +34,20 @@ export async function registerLedgerTools(agent: MCP) {
 			inputSchema: {
 				name: z.string().min(1),
 				emoji: z.string().min(1).default('🧒'),
+				transactionModalCss: z.string().optional(),
 			},
 		},
-		async ({ name, emoji }: { name: string; emoji: string }) => {
+		async ({
+			name,
+			emoji,
+			transactionModalCss,
+		}: {
+			name: string
+			emoji: string
+			transactionModalCss?: string
+		}) => {
 			const service = await createLedgerServiceForAgent(agent)
-			const created = await service.createKid({ name, emoji })
+			const created = await service.createKid({ name, emoji, transactionModalCss })
 			return {
 				...successContent('Kid created', `Created kid with id ${created.id}.`),
 				structuredContent: created,
@@ -50,24 +59,27 @@ export async function registerLedgerTools(agent: MCP) {
 		'ledger_update_kid',
 		{
 			title: 'Update Kid',
-			description: 'Update a kid name or emoji.',
+			description: 'Update a kid name, emoji, or transaction modal CSS.',
 			inputSchema: {
 				kidId: z.number().int().positive(),
 				name: z.string().min(1),
 				emoji: z.string().min(1),
+				transactionModalCss: z.string().optional(),
 			},
 		},
 		async ({
 			kidId,
 			name,
 			emoji,
+			transactionModalCss,
 		}: {
 			kidId: number
 			name: string
 			emoji: string
+			transactionModalCss?: string
 		}) => {
 			const service = await createLedgerServiceForAgent(agent)
-			await service.updateKid({ kidId, name, emoji })
+			await service.updateKid({ kidId, name, emoji, transactionModalCss })
 			return successContent('Kid updated', `Updated kid ${kidId}.`)
 		},
 	)

--- a/mcp/tools/ledger-tools.ts
+++ b/mcp/tools/ledger-tools.ts
@@ -55,7 +55,11 @@ export async function registerLedgerTools(agent: MCP) {
 			transactionModalCss?: string
 		}) => {
 			const service = await createLedgerServiceForAgent(agent)
-			const created = await service.createKid({ name, emoji, transactionModalCss })
+			const created = await service.createKid({
+				name,
+				emoji,
+				transactionModalCss,
+			})
 			return {
 				...successContent('Kid created', `Created kid with id ${created.id}.`),
 				structuredContent: created,

--- a/mcp/tools/ledger-tools.ts
+++ b/mcp/tools/ledger-tools.ts
@@ -4,6 +4,10 @@ import {
 	createLedgerServiceForAgent,
 	successContent,
 } from '#mcp/tools/ledger-tool-helpers.ts'
+import {
+	transactionModalCssCreateFieldDescription,
+	transactionModalCssUpdateFieldDescription,
+} from '#shared/transaction-modal-css.ts'
 
 export async function registerLedgerTools(agent: MCP) {
 	agent.server.registerTool(
@@ -30,11 +34,15 @@ export async function registerLedgerTools(agent: MCP) {
 		'ledger_create_kid',
 		{
 			title: 'Create Kid',
-			description: 'Create a kid profile.',
+			description:
+				'Create a kid profile with optional transaction modal CSS customization.',
 			inputSchema: {
 				name: z.string().min(1),
 				emoji: z.string().min(1).default('🧒'),
-				transactionModalCss: z.string().optional(),
+				transactionModalCss: z
+					.string()
+					.optional()
+					.describe(transactionModalCssCreateFieldDescription),
 			},
 		},
 		async ({
@@ -64,7 +72,10 @@ export async function registerLedgerTools(agent: MCP) {
 				kidId: z.number().int().positive(),
 				name: z.string().min(1),
 				emoji: z.string().min(1),
-				transactionModalCss: z.string().optional(),
+				transactionModalCss: z
+					.string()
+					.optional()
+					.describe(transactionModalCssUpdateFieldDescription),
 			},
 		},
 		async ({

--- a/migrations/0004-kid-transaction-modal-css.sql
+++ b/migrations/0004-kid-transaction-modal-css.sql
@@ -1,0 +1,2 @@
+ALTER TABLE kids
+ADD COLUMN transaction_modal_css TEXT NOT NULL DEFAULT '';

--- a/server/handlers/ledger-api.ts
+++ b/server/handlers/ledger-api.ts
@@ -11,6 +11,7 @@ import { type AppEnv } from '#types/env-schema.ts'
 const createKidSchema = object({
 	name: string(),
 	emoji: string(),
+	transactionModalCss: optional(string()),
 })
 
 const updateKidSchema = object({

--- a/server/handlers/ledger-api.ts
+++ b/server/handlers/ledger-api.ts
@@ -17,6 +17,7 @@ const updateKidSchema = object({
 	kidId: number(),
 	name: string(),
 	emoji: string(),
+	transactionModalCss: optional(string()),
 })
 
 const reorderKidsSchema = object({

--- a/server/ledger/ledger-service.ts
+++ b/server/ledger/ledger-service.ts
@@ -18,6 +18,7 @@ export type LedgerKid = {
 	householdId: number
 	name: string
 	emoji: string
+	transactionModalCss: string
 	sortOrder: number
 	isArchived: boolean
 	totalBalanceCents: number
@@ -132,13 +133,36 @@ export class LedgerService {
 		return { id: kidId }
 	}
 
-	async updateKid(input: { kidId: number; name: string; emoji: string }) {
+	async updateKid(input: {
+		kidId: number
+		name: string
+		emoji: string
+		transactionModalCss?: string
+	}) {
 		const kid = await this.#requireKid(input.kidId)
+		const normalizedTransactionModalCss =
+			typeof input.transactionModalCss === 'string'
+				? input.transactionModalCss
+				: undefined
+		if (normalizedTransactionModalCss === undefined) {
+			await this.#run(
+				`UPDATE kids
+				 SET name = ?, emoji = ?, updated_at = CURRENT_TIMESTAMP
+				 WHERE id = ?`,
+				[input.name.trim(), input.emoji.trim(), kid.id],
+			)
+			return
+		}
 		await this.#run(
 			`UPDATE kids
-			 SET name = ?, emoji = ?, updated_at = CURRENT_TIMESTAMP
+			 SET name = ?, emoji = ?, transaction_modal_css = ?, updated_at = CURRENT_TIMESTAMP
 			 WHERE id = ?`,
-			[input.name.trim(), input.emoji.trim(), kid.id],
+			[
+				input.name.trim(),
+				input.emoji.trim(),
+				normalizedTransactionModalCss,
+				kid.id,
+			],
 		)
 	}
 
@@ -645,7 +669,7 @@ export class LedgerService {
 	async exportLedgerData() {
 		const household = await this.#ensureHousehold()
 		const kids = await this.#all(
-			`SELECT id, name, emoji, sort_order, is_archived, archived_at, created_at, updated_at
+			`SELECT id, name, emoji, transaction_modal_css, sort_order, is_archived, archived_at, created_at, updated_at
 			 FROM kids
 			 WHERE household_id = ?
 			 ORDER BY sort_order ASC, id ASC`,
@@ -680,6 +704,7 @@ export class LedgerService {
 				id: getNumber(kid.id),
 				name: getString(kid.name),
 				emoji: getString(kid.emoji),
+				transactionModalCss: getString(kid.transaction_modal_css),
 				sortOrder: getNumber(kid.sort_order),
 				isArchived: getBoolean(kid.is_archived),
 				archivedAt: getString(kid.archived_at),
@@ -858,7 +883,7 @@ export class LedgerService {
 
 	async #listKids(householdId: number, includeArchived: boolean) {
 		const kidsRows = await this.#all(
-			`SELECT id, household_id, name, emoji, sort_order, is_archived
+			`SELECT id, household_id, name, emoji, transaction_modal_css, sort_order, is_archived
 			 FROM kids
 			 WHERE household_id = ? ${includeArchived ? '' : 'AND is_archived = 0'}
 			 ORDER BY sort_order ASC, id ASC`,
@@ -869,6 +894,7 @@ export class LedgerService {
 			householdId: getNumber(kidRow.household_id),
 			name: getString(kidRow.name),
 			emoji: getString(kidRow.emoji),
+			transactionModalCss: getString(kidRow.transaction_modal_css),
 			sortOrder: getNumber(kidRow.sort_order),
 			isArchived: getBoolean(kidRow.is_archived),
 			totalBalanceCents: 0,

--- a/server/ledger/ledger-service.ts
+++ b/server/ledger/ledger-service.ts
@@ -116,17 +116,31 @@ export class LedgerService {
 		}
 	}
 
-	async createKid(input: { name: string; emoji: string }) {
+	async createKid(input: {
+		name: string
+		emoji: string
+		transactionModalCss?: string
+	}) {
 		const household = await this.#ensureHousehold()
 		const nextSortOrder = await this.#nextSortOrder(
 			'kids',
 			'household_id',
 			household.id,
 		)
+		const transactionModalCss =
+			typeof input.transactionModalCss === 'string'
+				? input.transactionModalCss
+				: ''
 		const inserted = await this.#run(
-			`INSERT INTO kids (household_id, name, emoji, sort_order)
-			 VALUES (?, ?, ?, ?)`,
-			[household.id, input.name.trim(), input.emoji.trim(), nextSortOrder],
+			`INSERT INTO kids (household_id, name, emoji, transaction_modal_css, sort_order)
+			 VALUES (?, ?, ?, ?, ?)`,
+			[
+				household.id,
+				input.name.trim(),
+				input.emoji.trim(),
+				transactionModalCss,
+				nextSortOrder,
+			],
 		)
 		const kidId = inserted.meta?.last_row_id
 		invariant(typeof kidId === 'number', 'Could not create kid.')

--- a/shared/transaction-modal-css.ts
+++ b/shared/transaction-modal-css.ts
@@ -1,0 +1,24 @@
+export const transactionModalCssVariables = [
+	'--color-primary',
+	'--color-primary-hover',
+	'--color-primary-active',
+	'--color-on-primary',
+	'--color-primary-text',
+	'--color-surface',
+	'--color-text',
+	'--color-text-muted',
+	'--color-border',
+	'--font-family',
+	'--font-size-sm',
+	'--font-size-base',
+	'--font-size-lg',
+] as const
+
+const transactionModalCssVariableList = transactionModalCssVariables.join(', ')
+
+const transactionModalCssBaseFieldDescription =
+	"Custom CSS for a kid's transaction modal. Pass either variable declarations (automatically wrapped in :root { ... }) or a full stylesheet with selectors/@rules."
+
+export const transactionModalCssCreateFieldDescription = `${transactionModalCssBaseFieldDescription} Supported variables: ${transactionModalCssVariableList}. Omit to use defaults.`
+
+export const transactionModalCssUpdateFieldDescription = `${transactionModalCssBaseFieldDescription} Supported variables: ${transactionModalCssVariableList}. Omit to keep current CSS unchanged, or pass an empty string to clear saved custom CSS.`

--- a/types/tsconfig-client.json
+++ b/types/tsconfig-client.json
@@ -9,5 +9,9 @@
 		"jsx": "react-jsx",
 		"jsxImportSource": "remix/component"
 	},
-	"include": ["../client/**/*.ts", "../client/**/*.tsx"]
+	"include": [
+		"../client/**/*.ts",
+		"../client/**/*.tsx",
+		"../shared/**/*.ts"
+	]
 }

--- a/types/tsconfig-client.json
+++ b/types/tsconfig-client.json
@@ -9,9 +9,5 @@
 		"jsx": "react-jsx",
 		"jsxImportSource": "remix/component"
 	},
-	"include": [
-		"../client/**/*.ts",
-		"../client/**/*.tsx",
-		"../shared/**/*.ts"
-	]
+	"include": ["../client/**/*.ts", "../client/**/*.tsx", "../shared/**/*.ts"]
 }

--- a/types/tsconfig-tools.json
+++ b/types/tsconfig-tools.json
@@ -34,6 +34,8 @@
 		"../cli.ts",
 		"../docs/post-download.ts",
 		"../mcp/mcp-server-e2e.test.ts",
+		"../server/hex.ts",
+		"../server/password-hash.ts",
 		"../tools/**/*.ts",
 		"../shared/**/*.ts"
 	]

--- a/worker/db.ts
+++ b/worker/db.ts
@@ -61,6 +61,7 @@ export const kidsTable = createTable({
 		household_id: number(),
 		name: string(),
 		emoji: string(),
+		transaction_modal_css: string(),
 		sort_order: number(),
 		is_archived: number(),
 		archived_at: string(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds per-kid custom CSS for transaction modals, editable via a new settings modal, to allow UI customization.

This implements an end-to-end solution for user-requested per-kid UI customization. It includes database schema changes, API/service integration, a new settings modal for editing CSS with documentation and examples, and dynamic injection/removal of custom CSS into the transaction modal.

---
<p><a href="https://cursor.com/agents/bc-35e8f4e9-e29d-4a01-b663-60df1c90b663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35e8f4e9-e29d-4a01-b663-60df1c90b663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-kid transaction modal customization: in-settings CSS editor with live preview, font/@import support, keyboard-accessible modal, and saved CSS applied only while a kid’s modal is open.

* **Tests**
  * End-to-end and server-side tests validating create/update/save flows, live preview application while modal is open, and cleanup on close.

* **Chores**
  * Database migration and backend/API support to store and surface per-kid modal CSS.

* **Documentation**
  * Notes describing the editor, live preview, and apply-time behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->