### PR TITLE
Kids dialog current total

### DIFF
--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -449,12 +449,12 @@ export function HomeRoute(handle: Handle) {
 								<button
 									type="button"
 									disabled={
-										getCurrentTotalQuickAmountCents(transactionState) === 0
+										Math.abs(transactionState.account.balanceCents) === 0
 									}
 									on={{
 										click: () =>
 											setTransactionAmountFromQuick(
-												getCurrentTotalQuickAmountCents(transactionState),
+												Math.abs(transactionState.account.balanceCents),
 											),
 									}}
 									css={{
@@ -727,8 +727,4 @@ function LoggedOutHome() {
 			</section>
 		</section>
 	)
-}
-
-function getCurrentTotalQuickAmountCents(state: TransactionState) {
-	return Math.abs(state.account.balanceCents)
 }

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -446,6 +446,33 @@ export function HomeRoute(handle: Handle) {
 									gap: spacing.xs,
 								}}
 							>
+								<button
+									type="button"
+									disabled={
+										getCurrentTotalQuickAmountCents(transactionState) === 0
+									}
+									on={{
+										click: () =>
+											setTransactionAmountFromQuick(
+												getCurrentTotalQuickAmountCents(transactionState),
+											),
+									}}
+									css={{
+										...buttonCss,
+										backgroundColor: colors.surface,
+										color: colors.text,
+										border: `2px solid ${colors.border}`,
+										boxShadow: `0 2px 0 0 ${colors.border}`,
+										'&:active': {
+											transform: 'translateY(2px)',
+											boxShadow: `0 0 0 0 ${colors.border}`,
+										},
+									}}
+								>
+									{`Current Total (${formatCents(
+										transactionState.account.balanceCents,
+									)})`}
+								</button>
 								{quickAmounts.map((amount) => (
 									<button
 										key={amount}
@@ -700,4 +727,8 @@ function LoggedOutHome() {
 			</section>
 		</section>
 	)
+}
+
+function getCurrentTotalQuickAmountCents(state: TransactionState) {
+	return Math.abs(state.account.balanceCents)
 }

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -449,12 +449,12 @@ export function HomeRoute(handle: Handle) {
 								<button
 									type="button"
 									disabled={
-										Math.abs(transactionState.account.balanceCents) === 0
+										Math.abs(transactionState!.account.balanceCents) === 0
 									}
 									on={{
 										click: () =>
 											setTransactionAmountFromQuick(
-												Math.abs(transactionState.account.balanceCents),
+												Math.abs(transactionState!.account.balanceCents),
 											),
 									}}
 									css={{

--- a/docs/agents/setup.md
+++ b/docs/agents/setup.md
@@ -71,6 +71,9 @@ For a full local reset before seeding:
 After `bun run dev` is running and you are logged in:
 
 - `/` should render the main ledger board with family total and account cards.
+- `/` transaction modals should offer a `Current Total ($X.XX)` quick amount
+  button that mirrors the selected account balance and fills the amount field
+  with that value.
 - `/settings` should allow creating kids/accounts and managing archive/delete.
 - `/settings` kid cards should allow saving per-kid transaction modal CSS
   declarations/rules (including optional `@import` font rules), show a live

--- a/e2e/ledger.spec.ts
+++ b/e2e/ledger.spec.ts
@@ -22,3 +22,32 @@ test('parent can complete first kid/account/transaction flow', async ({
 			.first(),
 	).toBeVisible()
 })
+
+test('transaction modal includes a current total quick amount', async ({
+	page,
+	login,
+}) => {
+	await login()
+	const { accountName } = await createKidWithAccount(page)
+
+	await page.goto('/')
+	const accountButton = page.getByRole('button', {
+		name: new RegExp(accountName),
+	})
+
+	await accountButton.click()
+	await page.getByLabel('Amount').fill('4.25')
+	await page.getByRole('button', { name: 'Add' }).last().click()
+	await expect(page.getByText('Family Total:')).toContainText('$4.25')
+
+	await accountButton.click()
+	const modal = page.getByRole('dialog')
+	const currentTotalButton = modal.getByRole('button', {
+		name: 'Current Total ($4.25)',
+	})
+
+	await expect(currentTotalButton).toBeVisible()
+	await expect(currentTotalButton).toBeEnabled()
+	await currentTotalButton.click()
+	await expect(modal.getByLabel('Amount')).toHaveValue('4.25')
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a "Current Total" quick amount button to the transaction modal to quickly fill the amount field with the current account balance.

<div><a href="https://cursor.com/agents/bc-326e03e8-d4a4-43e5-91e2-4ce59e29c5f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-326e03e8-d4a4-43e5-91e2-4ce59e29c5f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Current Total" quick-amount button to the transaction modal that displays the current account balance. The button is disabled when the balance is zero and auto-fills the transaction amount when selected.

* **Documentation**
  * Updated documentation to reflect the new quick-amount button behavior.

* **Tests**
  * Added end-to-end test coverage for the new quick-amount button functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->