### PR TITLE
Full emoji display

### DIFF
--- a/client/emoji-utils.test.ts
+++ b/client/emoji-utils.test.ts
@@ -1,0 +1,24 @@
+/// <reference types="bun" />
+import { expect, test } from 'bun:test'
+
+import { fallbackKidEmoji, normalizeKidEmoji } from './emoji-utils.ts'
+
+test('normalizeKidEmoji preserves flag emoji graphemes', () => {
+	expect(normalizeKidEmoji('🇺🇸')).toBe('🇺🇸')
+})
+
+test('normalizeKidEmoji preserves zwj emoji graphemes', () => {
+	expect(normalizeKidEmoji('👨‍👩‍👧‍👦')).toBe('👨‍👩‍👧‍👦')
+})
+
+test('normalizeKidEmoji preserves emoji with modifiers', () => {
+	expect(normalizeKidEmoji('👍🏽')).toBe('👍🏽')
+})
+
+test('normalizeKidEmoji trims whitespace and keeps the first grapheme', () => {
+	expect(normalizeKidEmoji('  🇺🇸🇨🇦  ')).toBe('🇺🇸')
+})
+
+test('normalizeKidEmoji falls back when the input is blank', () => {
+	expect(normalizeKidEmoji('')).toBe(fallbackKidEmoji)
+})

--- a/client/emoji-utils.ts
+++ b/client/emoji-utils.ts
@@ -16,7 +16,7 @@ function getFirstGrapheme(value: string) {
 		if (firstGrapheme) return firstGrapheme
 	}
 
-	return Array.from(trimmedValue)[0]
+	return null
 }
 
 export function normalizeKidEmoji(value: string, fallback = fallbackKidEmoji) {

--- a/client/emoji-utils.ts
+++ b/client/emoji-utils.ts
@@ -16,7 +16,7 @@ function getFirstGrapheme(value: string) {
 		if (firstGrapheme) return firstGrapheme
 	}
 
-	return trimmedValue
+	return Array.from(trimmedValue)[0]
 }
 
 export function normalizeKidEmoji(value: string, fallback = fallbackKidEmoji) {

--- a/client/emoji-utils.ts
+++ b/client/emoji-utils.ts
@@ -1,0 +1,24 @@
+export const fallbackKidEmoji = '🧒'
+
+const graphemeSegmenter =
+	typeof Intl !== 'undefined' && 'Segmenter' in Intl
+		? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+		: null
+
+function getFirstGrapheme(value: string) {
+	const trimmedValue = value.trim()
+	if (!trimmedValue) return null
+
+	if (graphemeSegmenter !== null) {
+		const firstGrapheme = graphemeSegmenter
+			.segment(trimmedValue)
+			.containing(0)?.segment
+		if (firstGrapheme) return firstGrapheme
+	}
+
+	return trimmedValue
+}
+
+export function normalizeKidEmoji(value: string, fallback = fallbackKidEmoji) {
+	return getFirstGrapheme(value) ?? fallback
+}

--- a/client/emoji-utils.ts
+++ b/client/emoji-utils.ts
@@ -16,7 +16,8 @@ function getFirstGrapheme(value: string) {
 		if (firstGrapheme) return firstGrapheme
 	}
 
-	return null
+	const firstCodePoint = Array.from(trimmedValue)[0]
+	return firstCodePoint ?? null
 }
 
 export function normalizeKidEmoji(value: string, fallback = fallbackKidEmoji) {

--- a/client/routes/settings.tsx
+++ b/client/routes/settings.tsx
@@ -20,6 +20,7 @@ import {
 	clearKidModalBackground,
 	setKidModalBackground,
 } from '#client/kid-modal-background.ts'
+import { fallbackKidEmoji, normalizeKidEmoji } from '#client/emoji-utils.ts'
 import { formatCents } from '#client/money.ts'
 import {
 	accountColorTokens,
@@ -39,7 +40,7 @@ import { transactionModalCssVariables } from '#shared/transaction-modal-css.ts'
 import { handleModalKeydown } from '#client/dom-utils.ts'
 
 const defaultKidEmojis = [
-	'🧒',
+	fallbackKidEmoji,
 	'👦',
 	'👧',
 	'🧑',
@@ -435,7 +436,7 @@ export function SettingsRoute(handle: Handle) {
 			notify('Kid name is required.')
 			return
 		}
-		await createKid({ name: newKidName, emoji: newKidEmoji })
+		await createKid({ name: newKidName, emoji: normalizeKidEmoji(newKidEmoji) })
 		newKidName = ''
 		newKidEmoji = getRandomDefaultKidEmoji()
 		await refreshSettings()
@@ -552,11 +553,10 @@ export function SettingsRoute(handle: Handle) {
 									input: (event) => {
 										if (!(event.currentTarget instanceof HTMLInputElement))
 											return
-										newKidEmoji = event.currentTarget.value || '🧒'
+										newKidEmoji = normalizeKidEmoji(event.currentTarget.value)
 										handle.update()
 									},
 								}}
-								maxLength={2}
 								aria-label="Kid emoji"
 								css={{
 									...inputCss,
@@ -656,11 +656,15 @@ export function SettingsRoute(handle: Handle) {
 										defaultValue={kid.emoji}
 										aria-label={`${kid.name} emoji`}
 										data-kid-emoji={kid.id}
-										maxLength={2}
 										on={{
+											input: (event) => {
+												const input = event.currentTarget as HTMLInputElement
+												input.value = normalizeKidEmoji(input.value)
+											},
 											blur: async (e) => {
-												const emoji =
-													(e.currentTarget as HTMLInputElement).value || '🧒'
+												const input = e.currentTarget as HTMLInputElement
+												const emoji = normalizeKidEmoji(input.value)
+												input.value = emoji
 												const nameInput = document.querySelector(
 													`input[data-kid-name="${kid.id}"]`,
 												) as HTMLInputElement

--- a/e2e/kid-emoji.spec.ts
+++ b/e2e/kid-emoji.spec.ts
@@ -1,0 +1,26 @@
+import { createKid, expect, test } from './playwright-utils.ts'
+
+test('kid emoji fields preserve full emoji graphemes', async ({
+	page,
+	login,
+}) => {
+	const kidName = `Kid-${crypto.randomUUID().slice(0, 6)}`
+	const flagEmoji = '🇺🇸'
+	const familyEmoji = '👨‍👩‍👧‍👦'
+
+	await login()
+	await page.goto('/settings')
+	await createKid(page, { kidName, kidEmoji: flagEmoji })
+
+	const kidEmojiInput = page.getByRole('textbox', { name: `${kidName} emoji` })
+	await expect(kidEmojiInput).toHaveValue(flagEmoji)
+
+	await kidEmojiInput.fill(familyEmoji)
+	await kidEmojiInput.blur()
+	await expect(kidEmojiInput).toHaveValue(familyEmoji)
+
+	await page.goto('/')
+	await expect(
+		page.getByRole('heading', { name: `${familyEmoji} ${kidName}` }),
+	).toBeVisible()
+})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes emoji truncation in kid settings by using grapheme-aware normalization, allowing multi-codepoint emoji to display correctly.

The `maxLength={2}` attribute on kid emoji input fields was truncating multi-codepoint emoji (like flags, skin tones, and ZWJ sequences) because browsers count UTF-16 units, effectively splitting these emoji in half. This PR introduces a grapheme-aware normalization helper to ensure these complex emoji are treated as single units and preserved intact.

<div><a href="https://cursor.com/agents/bc-2f402bcc-66c2-4650-875b-eee7527ffc11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f402bcc-66c2-4650-875b-eee7527ffc11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved emoji handling to preserve complex graphemes (flags, ZWJ families, skin tone modifiers), trim whitespace, and consistently normalize emoji inputs across creation and edits.

* **Tests**
  * Added unit and end-to-end tests to verify emoji normalization and UI behavior for complex emoji scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->