### PR TITLE
Remember me session renewal

### DIFF
--- a/client/routes/login.tsx
+++ b/client/routes/login.tsx
@@ -81,6 +81,7 @@ export function LoginRoute(handle: Handle, setup: LoginFormSetup = {}) {
 		const formData = new FormData(event.currentTarget)
 		const email = String(formData.get('email') ?? '').trim()
 		const password = String(formData.get('password') ?? '')
+		const rememberMe = formData.get('rememberMe') === 'on'
 
 		if (!email || !password) {
 			setState('error', 'Email and password are required.')
@@ -94,7 +95,7 @@ export function LoginRoute(handle: Handle, setup: LoginFormSetup = {}) {
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				credentials: 'include',
-				body: JSON.stringify({ email, password, mode }),
+				body: JSON.stringify({ email, password, mode, rememberMe }),
 			})
 			const payload = await parseJsonOrNull<{ error?: string }>(response)
 
@@ -205,6 +206,31 @@ export function LoginRoute(handle: Handle, setup: LoginFormSetup = {}) {
 							}}
 						/>
 					</label>
+					{!isSignup ? (
+						<label
+							css={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: spacing.sm,
+								color: colors.text,
+								fontSize: typography.fontSize.sm,
+								fontWeight: typography.fontWeight.medium,
+								cursor: 'pointer',
+							}}
+						>
+							<input
+								type="checkbox"
+								name="rememberMe"
+								css={{
+									width: '1rem',
+									height: '1rem',
+									accentColor: colors.primary,
+									cursor: 'pointer',
+								}}
+							/>
+							<span>Remember me for 2 months</span>
+						</label>
+					) : null}
 					<button
 						type="submit"
 						disabled={isSubmitting}

--- a/docs/architecture/authentication.md
+++ b/docs/architecture/authentication.md
@@ -13,12 +13,16 @@ Session cookie behavior is implemented in `server/auth-session.ts`.
 - `httpOnly: true`
 - `sameSite: 'Lax'`
 - signed with `COOKIE_SECRET`
-- max age: 7 days
+- default max age: 7 days
+- remembered max age: 60 days when login sets `rememberMe: true`
+- remembered sessions automatically refresh back to 60 days after 30 days of
+  authenticated activity
 
 The cookie payload stores:
 
 - `id` (user id as string)
 - `email`
+- `rememberMe` and `issuedAtMs` for remembered sessions
 
 `server/handler.ts` calls `setAuthSessionSecret` on each request so cookie
 signing and verification are available to handlers.
@@ -27,11 +31,15 @@ signing and verification are available to handlers.
 
 `POST /auth` is implemented by `server/handlers/auth.ts`.
 
-- Accepts JSON body with `email`, `password`, and `mode` (`login` or `signup`)
+- Accepts JSON body with `email`, `password`, `mode` (`login` or `signup`), and
+  optional `rememberMe`
 - Uses D1 (`users` table) for user lookups and inserts
 - Hashes passwords with `server/password-hash.ts`
 - Returns signed session cookie via `Set-Cookie` on success
 - Emits structured audit events through `server/audit-log.ts`
+
+The login UI exposes a "Remember me for 2 months" checkbox. Signup continues to
+issue the default session cookie.
 
 Related handlers:
 

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -3,9 +3,26 @@ import {
 	expect,
 	loginViaUi,
 	test,
+	type Page,
 } from './playwright-utils.ts'
 
 const testUser = { email: 'user@example.com', password: 'password123' }
+const secondsPerDay = 60 * 60 * 24
+
+async function expectSessionCookieLifetimeInDays(
+	page: Page,
+	minDays: number,
+	maxDays: number,
+) {
+	const sessionCookie = (await page.context().cookies()).find(
+		(cookie) => cookie.name === 'kids-ledger_session',
+	)
+	expect(sessionCookie).toBeDefined()
+	const issuedAtSeconds = Math.floor(Date.now() / 1000)
+	const lifetimeSeconds = (sessionCookie?.expires ?? 0) - issuedAtSeconds
+	expect(lifetimeSeconds).toBeGreaterThan(minDays * secondsPerDay)
+	expect(lifetimeSeconds).toBeLessThan(maxDays * secondsPerDay)
+}
 
 test('logs in with email and password', async ({ page }) => {
 	await ensureUserExists(page.request, testUser)
@@ -16,6 +33,26 @@ test('logs in with email and password', async ({ page }) => {
 	await expect(
 		page.getByRole('heading', { name: `Welcome, ${testUser.email}` }),
 	).toBeVisible()
+	await expectSessionCookieLifetimeInDays(page, 6, 8)
+})
+
+test('extends login lifetime when remember me is checked', async ({ page }) => {
+	await ensureUserExists(page.request, {
+		email: 'remember-me@example.com',
+		password: testUser.password,
+	})
+	await page.context().clearCookies()
+	await loginViaUi(
+		page,
+		{ email: 'remember-me@example.com', password: testUser.password },
+		{ rememberMe: true },
+	)
+
+	await expect(page).toHaveURL(/\/account$/)
+	await expect(
+		page.getByRole('heading', { name: 'Welcome, remember-me@example.com' }),
+	).toBeVisible()
+	await expectSessionCookieLifetimeInDays(page, 59, 61)
 })
 
 test('signs up with email and password', async ({ page }) => {

--- a/e2e/playwright-utils.ts
+++ b/e2e/playwright-utils.ts
@@ -51,10 +51,17 @@ export async function ensureUserExists(
 	return credentials
 }
 
-export async function loginViaUi(page: Page, credentials: UserCredentials) {
+export async function loginViaUi(
+	page: Page,
+	credentials: UserCredentials,
+	options?: { rememberMe?: boolean },
+) {
 	await page.goto('/login')
 	await page.getByLabel('Email').fill(credentials.email)
 	await page.getByLabel('Password').fill(credentials.password)
+	if (options?.rememberMe) {
+		await page.getByLabel('Remember me for 2 months').check()
+	}
 	await page.getByRole('button', { name: 'Sign in' }).click()
 }
 

--- a/server/auth-session.test.ts
+++ b/server/auth-session.test.ts
@@ -1,0 +1,72 @@
+/// <reference types="bun" />
+import { beforeAll, expect, test } from 'bun:test'
+import {
+	authSessionMaxAgeSeconds,
+	createAuthCookie,
+	readAuthSessionState,
+	rememberedAuthSessionMaxAgeSeconds,
+	rememberedAuthSessionRefreshAfterSeconds,
+	setAuthSessionSecret,
+} from './auth-session.ts'
+
+const testCookieSecret = 'test-cookie-secret-0123456789abcdef0123456789'
+const baseSession = { id: '1', email: 'test@example.com' }
+
+function toCookieHeader(setCookieHeader: string) {
+	return setCookieHeader.split(';')[0] ?? ''
+}
+
+function createSessionRequest(cookieHeader: string) {
+	return new Request('http://example.com/session', {
+		headers: { Cookie: cookieHeader },
+	})
+}
+
+beforeAll(() => {
+	setAuthSessionSecret(testCookieSecret)
+})
+
+test('readAuthSessionState keeps standard sessions readable without refreshing', async () => {
+	const issuedAtMs = Date.UTC(2026, 0, 1)
+	const setCookieHeader = await createAuthCookie(baseSession, {
+		secure: false,
+		now: issuedAtMs,
+	})
+	const state = await readAuthSessionState(
+		createSessionRequest(toCookieHeader(setCookieHeader)),
+		{ now: issuedAtMs + authSessionMaxAgeSeconds * 1000 - 1_000 },
+	)
+
+	expect(state.session).toEqual(baseSession)
+	expect(state.rememberMe).toBe(false)
+	expect(state.headers).toBeNull()
+	expect(state.refreshAtMs).toBeNull()
+	expect(state.expiresAtMs).toBeNull()
+})
+
+test('readAuthSessionState refreshes remembered sessions after 30 days', async () => {
+	const issuedAtMs = Date.UTC(2026, 0, 1)
+	const setCookieHeader = await createAuthCookie(baseSession, {
+		secure: false,
+		rememberMe: true,
+		now: issuedAtMs,
+	})
+	const refreshedAtMs =
+		issuedAtMs + rememberedAuthSessionRefreshAfterSeconds * 1000 + 1_000
+	const state = await readAuthSessionState(
+		createSessionRequest(toCookieHeader(setCookieHeader)),
+		{ now: refreshedAtMs },
+	)
+
+	expect(state.session).toEqual(baseSession)
+	expect(state.rememberMe).toBe(true)
+	expect(state.headers?.get('Set-Cookie')).toContain(
+		`Max-Age=${rememberedAuthSessionMaxAgeSeconds}`,
+	)
+	expect(state.refreshAtMs).toBe(
+		refreshedAtMs + rememberedAuthSessionRefreshAfterSeconds * 1000,
+	)
+	expect(state.expiresAtMs).toBe(
+		refreshedAtMs + rememberedAuthSessionMaxAgeSeconds * 1000,
+	)
+})

--- a/server/auth-session.test.ts
+++ b/server/auth-session.test.ts
@@ -70,3 +70,24 @@ test('readAuthSessionState refreshes remembered sessions after 30 days', async (
 		refreshedAtMs + rememberedAuthSessionMaxAgeSeconds * 1000,
 	)
 })
+
+test('readAuthSessionState rejects expired remembered sessions', async () => {
+	const issuedAtMs = Date.UTC(2026, 0, 1)
+	const setCookieHeader = await createAuthCookie(baseSession, {
+		secure: false,
+		rememberMe: true,
+		now: issuedAtMs,
+	})
+	const expiredAtMs =
+		issuedAtMs + rememberedAuthSessionMaxAgeSeconds * 1000 + 1_000
+	const state = await readAuthSessionState(
+		createSessionRequest(toCookieHeader(setCookieHeader)),
+		{ now: expiredAtMs },
+	)
+
+	expect(state.session).toBeNull()
+	expect(state.rememberMe).toBe(false)
+	expect(state.headers).toBeNull()
+	expect(state.refreshAtMs).toBeNull()
+	expect(state.expiresAtMs).toBeNull()
+})

--- a/server/auth-session.ts
+++ b/server/auth-session.ts
@@ -239,6 +239,16 @@ export async function readAuthSessionState(
 	const refreshAtMs = parsed.issuedAtMs + rememberedAuthSessionRefreshAfterMs
 	const expiresAtMs = parsed.issuedAtMs + rememberedAuthSessionMaxAgeMs
 
+	if (now >= expiresAtMs) {
+		return {
+			session: null,
+			headers: null,
+			rememberMe: false,
+			refreshAtMs: null,
+			expiresAtMs: null,
+		}
+	}
+
 	if (now < refreshAtMs) {
 		return {
 			session,

--- a/server/auth-session.ts
+++ b/server/auth-session.ts
@@ -87,6 +87,12 @@ function isStoredAuthSession(value: unknown): value is StoredAuthSession {
 	)
 }
 
+function isRememberedAuthSession(
+	session: StoredAuthSession,
+): session is RememberedAuthSession {
+	return 'rememberMe' in session && session.rememberMe === true
+}
+
 function createStoredAuthSession(
 	session: AuthSession,
 	rememberMe: boolean,
@@ -219,7 +225,7 @@ export async function readAuthSessionState(
 		email: parsed.email,
 	}
 
-	if (!('rememberMe' in parsed) || parsed.rememberMe !== true) {
+	if (!isRememberedAuthSession(parsed)) {
 		return {
 			session,
 			headers: null,

--- a/server/auth-session.ts
+++ b/server/auth-session.ts
@@ -1,10 +1,31 @@
 import { createCookie } from '@remix-run/cookie'
 
-const sessionMaxAgeSeconds = 60 * 60 * 24 * 7
+export const authSessionMaxAgeSeconds = 60 * 60 * 24 * 7
+export const rememberedAuthSessionMaxAgeSeconds = 60 * 60 * 24 * 60
+export const rememberedAuthSessionRefreshAfterSeconds = 60 * 60 * 24 * 30
+
+const rememberedAuthSessionMaxAgeMs = rememberedAuthSessionMaxAgeSeconds * 1000
+const rememberedAuthSessionRefreshAfterMs =
+	rememberedAuthSessionRefreshAfterSeconds * 1000
 
 export type AuthSession = {
 	id: string
 	email: string
+}
+
+type RememberedAuthSession = AuthSession & {
+	rememberMe: true
+	issuedAtMs: number
+}
+
+type StoredAuthSession = AuthSession | RememberedAuthSession
+
+export type AuthSessionState = {
+	session: AuthSession | null
+	headers: Headers | null
+	rememberMe: boolean
+	refreshAtMs: number | null
+	expiresAtMs: number | null
 }
 
 let sessionCookie: ReturnType<typeof createCookie> | null = null
@@ -24,7 +45,7 @@ export function setAuthSessionSecret(secret: string) {
 		httpOnly: true,
 		sameSite: 'Lax',
 		path: '/',
-		maxAge: sessionMaxAgeSeconds,
+		maxAge: authSessionMaxAgeSeconds,
 		secrets: [secret],
 	})
 }
@@ -48,8 +69,104 @@ function isAuthSession(value: unknown): value is AuthSession {
 	)
 }
 
-export async function createAuthCookie(session: AuthSession, secure: boolean) {
-	return getSessionCookie().serialize(JSON.stringify(session), { secure })
+function isStoredAuthSession(value: unknown): value is StoredAuthSession {
+	if (!isAuthSession(value)) {
+		return false
+	}
+
+	const record = value as Record<string, unknown>
+	if (record.rememberMe === undefined && record.issuedAtMs === undefined) {
+		return true
+	}
+
+	return (
+		record.rememberMe === true &&
+		typeof record.issuedAtMs === 'number' &&
+		Number.isFinite(record.issuedAtMs) &&
+		record.issuedAtMs > 0
+	)
+}
+
+function createStoredAuthSession(
+	session: AuthSession,
+	rememberMe: boolean,
+	now: number,
+): StoredAuthSession {
+	if (!rememberMe) {
+		return session
+	}
+
+	return {
+		...session,
+		rememberMe: true,
+		issuedAtMs: now,
+	}
+}
+
+function parseStoredAuthSession(stored: string) {
+	try {
+		const parsed = JSON.parse(stored)
+		return isStoredAuthSession(parsed) ? parsed : null
+	} catch {
+		return null
+	}
+}
+
+function normalizeProto(value: string) {
+	return value.trim().replace(/^"|"$/g, '').toLowerCase()
+}
+
+function getForwardedProto(request: Request) {
+	const forwarded = request.headers.get('forwarded')
+	if (forwarded) {
+		for (const entry of forwarded.split(',')) {
+			for (const pair of entry.split(';')) {
+				const [key, rawValue] = pair.split('=')
+				if (!key || !rawValue) continue
+				if (key.trim().toLowerCase() === 'proto') {
+					return normalizeProto(rawValue)
+				}
+			}
+		}
+	}
+
+	const xForwardedProto = request.headers.get('x-forwarded-proto')
+	if (xForwardedProto) {
+		return normalizeProto(xForwardedProto.split(',')[0] ?? '')
+	}
+
+	return null
+}
+
+export function isSecureRequest(request: Request) {
+	const forwardedProto = getForwardedProto(request)
+	if (forwardedProto) {
+		return forwardedProto === 'https'
+	}
+
+	return new URL(request.url).protocol === 'https:'
+}
+
+export async function createAuthCookie(
+	session: AuthSession,
+	options: {
+		secure: boolean
+		rememberMe?: boolean
+		now?: number
+	},
+) {
+	const rememberMe = options.rememberMe === true
+	return getSessionCookie().serialize(
+		JSON.stringify(
+			createStoredAuthSession(session, rememberMe, options.now ?? Date.now()),
+		),
+		{
+			secure: options.secure,
+			maxAge: rememberMe
+				? rememberedAuthSessionMaxAgeSeconds
+				: authSessionMaxAgeSeconds,
+		},
+	)
 }
 
 export async function destroyAuthCookie(secure: boolean) {
@@ -60,21 +177,89 @@ export async function destroyAuthCookie(secure: boolean) {
 	})
 }
 
-export async function readAuthSession(request: Request) {
+export async function readAuthSessionState(
+	request: Request,
+	options?: { now?: number },
+): Promise<AuthSessionState> {
 	const cookieHeader = request.headers.get('Cookie')
-	if (!cookieHeader) return null
-
-	const stored = await getSessionCookie().parse(cookieHeader)
-	if (!stored || typeof stored !== 'string') return null
-
-	try {
-		const parsed = JSON.parse(stored)
-		if (isAuthSession(parsed)) {
-			return parsed
+	if (!cookieHeader) {
+		return {
+			session: null,
+			headers: null,
+			rememberMe: false,
+			refreshAtMs: null,
+			expiresAtMs: null,
 		}
-	} catch {
-		return null
 	}
 
-	return null
+	const stored = await getSessionCookie().parse(cookieHeader)
+	if (!stored || typeof stored !== 'string') {
+		return {
+			session: null,
+			headers: null,
+			rememberMe: false,
+			refreshAtMs: null,
+			expiresAtMs: null,
+		}
+	}
+
+	const parsed = parseStoredAuthSession(stored)
+	if (!parsed) {
+		return {
+			session: null,
+			headers: null,
+			rememberMe: false,
+			refreshAtMs: null,
+			expiresAtMs: null,
+		}
+	}
+
+	const session = {
+		id: parsed.id,
+		email: parsed.email,
+	}
+
+	if (!('rememberMe' in parsed) || parsed.rememberMe !== true) {
+		return {
+			session,
+			headers: null,
+			rememberMe: false,
+			refreshAtMs: null,
+			expiresAtMs: null,
+		}
+	}
+
+	const now = options?.now ?? Date.now()
+	const refreshAtMs = parsed.issuedAtMs + rememberedAuthSessionRefreshAfterMs
+	const expiresAtMs = parsed.issuedAtMs + rememberedAuthSessionMaxAgeMs
+
+	if (now < refreshAtMs) {
+		return {
+			session,
+			headers: null,
+			rememberMe: true,
+			refreshAtMs,
+			expiresAtMs,
+		}
+	}
+
+	const refreshedAtMs = now
+	const refreshedCookie = await createAuthCookie(session, {
+		secure: isSecureRequest(request),
+		rememberMe: true,
+		now: refreshedAtMs,
+	})
+
+	return {
+		session,
+		headers: new Headers({ 'Set-Cookie': refreshedCookie }),
+		rememberMe: true,
+		refreshAtMs: refreshedAtMs + rememberedAuthSessionRefreshAfterMs,
+		expiresAtMs: refreshedAtMs + rememberedAuthSessionMaxAgeMs,
+	}
+}
+
+export async function readAuthSession(request: Request) {
+	const state = await readAuthSessionState(request)
+	return state.session
 }

--- a/server/handlers/auth-handler.test.ts
+++ b/server/handlers/auth-handler.test.ts
@@ -1,7 +1,10 @@
 /// <reference types="bun" />
 import { beforeAll, expect, test } from 'bun:test'
 import { RequestContext } from 'remix/fetch-router'
-import { setAuthSessionSecret } from '#server/auth-session.ts'
+import {
+	rememberedAuthSessionMaxAgeSeconds,
+	setAuthSessionSecret,
+} from '#server/auth-session.ts'
 import { createPasswordHash } from '#server/password-hash.ts'
 import { createAuthHandler } from './auth.ts'
 
@@ -219,6 +222,30 @@ test('auth handler returns ok with a session cookie for login', async () => {
 	expect(payload).toEqual({ ok: true, mode: 'login' })
 	const setCookie = response.headers.get('Set-Cookie') ?? ''
 	expect(setCookie).toContain('kids-ledger_session=')
+})
+
+test('auth handler extends cookie lifetime when remember me is enabled', async () => {
+	const testDb = createTestDb()
+	const handler = createAuthHandler({
+		COOKIE_SECRET: testCookieSecret,
+		APP_DB: testDb.db,
+	})
+	await testDb.addUser('remember@b.com', 'secret')
+	const authRequest = createAuthRequest(
+		{
+			email: 'remember@b.com',
+			password: 'secret',
+			mode: 'login',
+			rememberMe: true,
+		},
+		'http://example.com/auth',
+		handler,
+	)
+	const response = await authRequest.run()
+	expect(response.status).toBe(200)
+	const setCookie = response.headers.get('Set-Cookie') ?? ''
+	expect(setCookie).toContain('kids-ledger_session=')
+	expect(setCookie).toContain(`Max-Age=${rememberedAuthSessionMaxAgeSeconds}`)
 })
 
 test('auth handler sets Secure cookie over https', async () => {

--- a/server/handlers/auth-page.ts
+++ b/server/handlers/auth-page.ts
@@ -14,10 +14,12 @@ export function createAuthPageHandler() {
 					url.searchParams.get('redirectTo'),
 				)
 				const redirectTarget = redirectTo ?? '/account'
-				const response = Response.redirect(
-					new URL(redirectTarget, request.url),
-					302,
-				)
+				const response = new Response(null, {
+					status: 302,
+					headers: {
+						Location: new URL(redirectTarget, request.url).toString(),
+					},
+				})
 				if (authSession.headers) {
 					for (const [key, value] of authSession.headers) {
 						response.headers.append(key, value)

--- a/server/handlers/auth-page.ts
+++ b/server/handlers/auth-page.ts
@@ -1,4 +1,4 @@
-import { readAuthSession } from '#server/auth-session.ts'
+import { readAuthSessionState } from '#server/auth-session.ts'
 import { Layout } from '#server/layout.ts'
 import { render } from '#server/render.ts'
 import { normalizeRedirectTarget } from '#shared/redirect-target.ts'
@@ -8,17 +8,32 @@ export function createAuthPageHandler() {
 		middleware: [],
 		async action({ request }: { request: Request }) {
 			const url = new URL(request.url)
-			const session = await readAuthSession(request)
-			if (session) {
+			const authSession = await readAuthSessionState(request)
+			if (authSession.session) {
 				const redirectTo = normalizeRedirectTarget(
 					url.searchParams.get('redirectTo'),
 				)
 				const redirectTarget = redirectTo ?? '/account'
-				return Response.redirect(new URL(redirectTarget, request.url), 302)
+				const response = Response.redirect(
+					new URL(redirectTarget, request.url),
+					302,
+				)
+				if (authSession.headers) {
+					for (const [key, value] of authSession.headers) {
+						response.headers.append(key, value)
+					}
+				}
+				return response
 			}
 
 			const pageTitle = url.pathname === '/signup' ? 'Sign Up' : 'Sign In'
-			return render(Layout({ title: pageTitle }))
+			const response = render(Layout({ title: pageTitle }))
+			if (authSession.headers) {
+				for (const [key, value] of authSession.headers) {
+					response.headers.append(key, value)
+				}
+			}
+			return response
 		},
 	}
 }

--- a/server/handlers/auth.ts
+++ b/server/handlers/auth.ts
@@ -1,6 +1,6 @@
 import { type BuildAction } from 'remix/fetch-router'
-import { enum_, object, string } from 'remix/data-schema'
-import { createAuthCookie } from '#server/auth-session.ts'
+import { boolean, enum_, object, optional, string } from 'remix/data-schema'
+import { createAuthCookie, isSecureRequest } from '#server/auth-session.ts'
 import { getRequestIp, logAuditEvent } from '#server/audit-log.ts'
 import { normalizeEmail } from '#server/normalize-email.ts'
 import { createPasswordHash } from '#server/password-hash.ts'
@@ -23,6 +23,7 @@ const authRequestSchema = object({
 	email: string(),
 	password: string(),
 	mode: enum_(authModes),
+	rememberMe: optional(boolean()),
 })
 
 export function createAuthHandler(appEnv: AppEnv) {
@@ -48,6 +49,7 @@ export function createAuthHandler(appEnv: AppEnv) {
 			const normalizedEmail = normalizeEmail(parsedBody.value.email)
 			const normalizedPassword = parsedBody.value.password
 			const normalizedMode: AuthMode = parsedBody.value.mode
+			const rememberMe = parsedBody.value.rememberMe === true
 			const requestIp = getRequestIp(request) ?? undefined
 
 			if (!normalizedEmail || !normalizedPassword) {
@@ -138,7 +140,7 @@ export function createAuthHandler(appEnv: AppEnv) {
 
 				const cookie = await createAuthCookie(
 					{ id: String(record.id), email: normalizedEmail },
-					url.protocol === 'https:',
+					{ secure: isSecureRequest(request) },
 				)
 				void logAuditEvent({
 					category: 'auth',
@@ -184,7 +186,7 @@ export function createAuthHandler(appEnv: AppEnv) {
 					id: String(credentials.userId),
 					email: normalizedEmail,
 				},
-				url.protocol === 'https:',
+				{ secure: isSecureRequest(request), rememberMe },
 			)
 			void logAuditEvent({
 				category: 'auth',

--- a/server/handlers/ledger-api.ts
+++ b/server/handlers/ledger-api.ts
@@ -123,6 +123,7 @@ function createLedgerMutationHandler<Input, Result = void>(
 			return jsonResponse(
 				{ ok: true, ...(setup.mapResponse?.(result) ?? {}) },
 				setup.status,
+				access.headers ?? undefined,
 			)
 		},
 	}
@@ -135,7 +136,11 @@ export function createLedgerDashboardHandler(appEnv: AppEnv) {
 			const access = await readLedgerService(request, appEnv)
 			if (!access.ok) return access.response
 			const dashboard = await access.service.getDashboard()
-			return jsonResponse({ ok: true, dashboard })
+			return jsonResponse(
+				{ ok: true, dashboard },
+				200,
+				access.headers ?? undefined,
+			)
 		},
 	} satisfies BuildAction<
 		typeof routes.apiLedgerDashboard.method,
@@ -154,10 +159,14 @@ export function createLedgerSettingsHandler(appEnv: AppEnv) {
 				access.service.listArchived(),
 				access.service.listQuickAmounts(),
 			])
-			return jsonResponse({
-				ok: true,
-				settings: { kids, archived, quickAmounts },
-			})
+			return jsonResponse(
+				{
+					ok: true,
+					settings: { kids, archived, quickAmounts },
+				},
+				200,
+				access.headers ?? undefined,
+			)
 		},
 	} satisfies BuildAction<
 		typeof routes.apiLedgerSettings.method,
@@ -185,7 +194,11 @@ export function createLedgerHistoryHandler(appEnv: AppEnv) {
 				limit: getPositiveIntQueryParam(url, 'limit'),
 				offset: getNumberQueryParam(url, 'offset'),
 			})
-			return jsonResponse({ ok: true, ...result })
+			return jsonResponse(
+				{ ok: true, ...result },
+				200,
+				access.headers ?? undefined,
+			)
 		},
 	} satisfies BuildAction<
 		typeof routes.apiLedgerHistory.method,
@@ -355,6 +368,9 @@ export function createExportJsonHandler(appEnv: AppEnv) {
 					'Content-Disposition':
 						'attachment; filename="kids-ledger-export.json"',
 					'Cache-Control': 'no-store',
+					...(access.headers
+						? Object.fromEntries(access.headers.entries())
+						: {}),
 				},
 			})
 		},

--- a/server/handlers/ledger-api.ts
+++ b/server/handlers/ledger-api.ts
@@ -362,17 +362,20 @@ export function createExportJsonHandler(appEnv: AppEnv) {
 			const access = await readLedgerService(request, appEnv)
 			if (!access.ok) return access.response
 			const payload = await access.service.exportLedgerData()
-			return new Response(JSON.stringify(payload, null, 2), {
+			const response = new Response(JSON.stringify(payload, null, 2), {
 				headers: {
 					'Content-Type': 'application/json',
 					'Content-Disposition':
 						'attachment; filename="kids-ledger-export.json"',
 					'Cache-Control': 'no-store',
-					...(access.headers
-						? Object.fromEntries(access.headers.entries())
-						: {}),
 				},
 			})
+			if (access.headers) {
+				for (const [key, value] of access.headers) {
+					response.headers.append(key, value)
+				}
+			}
+			return response
 		},
 	} satisfies BuildAction<
 		typeof routes.apiExportJson.method,

--- a/server/handlers/logout.ts
+++ b/server/handlers/logout.ts
@@ -1,40 +1,6 @@
 import { type BuildAction } from 'remix/fetch-router'
-import { destroyAuthCookie } from '#server/auth-session.ts'
+import { destroyAuthCookie, isSecureRequest } from '#server/auth-session.ts'
 import { type routes } from '#server/routes.ts'
-
-function normalizeProto(value: string) {
-	return value.trim().replace(/^"|"$/g, '').toLowerCase()
-}
-
-function getForwardedProto(request: Request) {
-	const forwarded = request.headers.get('forwarded')
-	if (forwarded) {
-		for (const entry of forwarded.split(',')) {
-			for (const pair of entry.split(';')) {
-				const [key, rawValue] = pair.split('=')
-				if (!key || !rawValue) continue
-				if (key.trim().toLowerCase() === 'proto') {
-					return normalizeProto(rawValue)
-				}
-			}
-		}
-	}
-
-	const xForwardedProto = request.headers.get('x-forwarded-proto')
-	if (xForwardedProto) {
-		return normalizeProto(xForwardedProto.split(',')[0] ?? '')
-	}
-
-	return null
-}
-
-function isSecureRequest(request: Request) {
-	const forwardedProto = getForwardedProto(request)
-	if (forwardedProto) {
-		return forwardedProto === 'https'
-	}
-	return new URL(request.url).protocol === 'https:'
-}
 
 export const logout = {
 	middleware: [],

--- a/server/handlers/session.ts
+++ b/server/handlers/session.ts
@@ -1,27 +1,30 @@
 import { type BuildAction } from 'remix/fetch-router'
-import { readAuthSession } from '#server/auth-session.ts'
+import { readAuthSessionState } from '#server/auth-session.ts'
 import { type routes } from '#server/routes.ts'
 
 function jsonResponse(data: unknown, init?: ResponseInit) {
+	const headers = new Headers(init?.headers)
+	headers.set('Content-Type', 'application/json')
+	headers.set('Cache-Control', 'no-store')
+
 	return new Response(JSON.stringify(data), {
 		...init,
-		headers: {
-			'Content-Type': 'application/json',
-			'Cache-Control': 'no-store',
-			...init?.headers,
-		},
+		headers,
 	})
 }
 
 export const session = {
 	middleware: [],
 	async action({ request }) {
-		const session = await readAuthSession(request)
-		if (!session) {
+		const authSession = await readAuthSessionState(request)
+		if (!authSession.session) {
 			return jsonResponse({ ok: false })
 		}
 
-		return jsonResponse({ ok: true, session: { email: session.email } })
+		return jsonResponse(
+			{ ok: true, session: { email: authSession.session.email } },
+			{ headers: authSession.headers ?? undefined },
+		)
 	},
 } satisfies BuildAction<
 	typeof routes.session.method,

--- a/server/ledger/ledger-request.ts
+++ b/server/ledger/ledger-request.ts
@@ -1,18 +1,18 @@
 import { type Schema } from 'remix/data-schema'
-import { readAuthSession } from '#server/auth-session.ts'
+import { readAuthSessionState } from '#server/auth-session.ts'
 import { createLedgerService } from '#server/ledger/ledger-service.ts'
 import { parseJsonBody as parseJsonRequestBody } from '#server/request-parsing.ts'
 import { type AppEnv } from '#types/env-schema.ts'
 
 export async function readLedgerService(request: Request, appEnv: AppEnv) {
-	const session = await readAuthSession(request)
-	if (!session) {
+	const authSession = await readAuthSessionState(request)
+	if (!authSession.session) {
 		return {
 			ok: false as const,
 			response: jsonResponse({ error: 'Unauthorized.' }, 401),
 		}
 	}
-	const userId = Number(session.id)
+	const userId = Number(authSession.session.id)
 	if (!Number.isInteger(userId) || userId <= 0) {
 		return {
 			ok: false as const,
@@ -22,6 +22,7 @@ export async function readLedgerService(request: Request, appEnv: AppEnv) {
 	return {
 		ok: true as const,
 		service: createLedgerService(appEnv.APP_DB, userId),
+		headers: authSession.headers,
 	}
 }
 
@@ -48,12 +49,17 @@ export async function parseJsonBody<Output>(
 	}
 }
 
-export function jsonResponse(payload: unknown, status = 200) {
+export function jsonResponse(
+	payload: unknown,
+	status = 200,
+	headers?: HeadersInit,
+) {
+	const responseHeaders = new Headers(headers)
+	responseHeaders.set('Content-Type', 'application/json')
+	responseHeaders.set('Cache-Control', 'no-store')
+
 	return new Response(JSON.stringify(payload), {
 		status,
-		headers: {
-			'Content-Type': 'application/json',
-			'Cache-Control': 'no-store',
-		},
+		headers: responseHeaders,
 	})
 }

--- a/server/protected-page.ts
+++ b/server/protected-page.ts
@@ -1,12 +1,19 @@
-import { readAuthSession } from '#server/auth-session.ts'
+import { readAuthSessionState } from '#server/auth-session.ts'
 import { redirectToLogin } from '#server/auth-redirect.ts'
 import { Layout } from '#server/layout.ts'
 import { render } from '#server/render.ts'
 
 export async function renderProtectedPage(request: Request, title: string) {
-	const session = await readAuthSession(request)
-	if (!session) {
+	const authSession = await readAuthSessionState(request)
+	if (!authSession.session) {
 		return redirectToLogin(request)
 	}
-	return render(Layout({ title }))
+
+	const response = render(Layout({ title }))
+	if (authSession.headers) {
+		for (const [key, value] of authSession.headers) {
+			response.headers.append(key, value)
+		}
+	}
+	return response
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a 'Remember me' checkbox to the login form, enabling 60-day sessions that auto-renew after 30 days of activity.

<div><a href="https://cursor.com/agents/bc-8aaa7fa8-16d6-4664-8ac5-b51c570b3dd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8aaa7fa8-16d6-4664-8ac5-b51c570b3dd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Remember me for 2 months" option on the login form to create extended ~60‑day sessions that refresh after ~30 days of activity.

* **Documentation**
  * Updated authentication docs to describe the remember‑me option, cookie lifetime, and refresh behavior.

* **Tests**
  * Added end-to-end and unit tests validating the remember‑me login flow and session lifetime/refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->