### PR TITLE
Add account transfer flow

### DIFF
--- a/client/ledger-api.ts
+++ b/client/ledger-api.ts
@@ -238,6 +238,24 @@ export async function createTransaction(input: {
 	}>('/ledger/transactions/create', input)
 }
 
+export async function createTransfer(input: {
+	fromAccountId: number
+	toAccountId: number
+	amountCents: number
+	note?: string
+}) {
+	return postJson<{
+		ok: true
+		result: {
+			fromAccountId: number
+			fromBalanceCents: number
+			toAccountId: number
+			toBalanceCents: number
+			warning: string | null
+		}
+	}>('/ledger/transfers/create', input)
+}
+
 export async function setQuickAmounts(amounts: Array<number>) {
 	return postJson<{ ok: true; quickAmounts: Array<number> }>(
 		'/ledger/quick-amounts/set',

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -41,8 +41,7 @@ type TransactionState = {
 }
 
 type TransferState = {
-	fromKid: KidSummary
-	fromAccount: KidAccount
+	fromAccountId: string
 	toAccountId: string
 	amount: string
 	note: string
@@ -140,24 +139,26 @@ export function HomeRoute(handle: Handle) {
 		})
 	}
 
-	function openTransferModal(
-		kid: KidSummary,
-		account: KidAccount,
-		opener: HTMLButtonElement,
-	) {
+	function openTransferModal(opener: HTMLButtonElement) {
 		clearTransferCloseModalTimeout()
-		setKidModalBackground(kid.emoji)
 		transferModalOpener = opener
 		transferModalClosing = false
-		const destination = getDefaultTransferDestination(kid, account, kids)
+		const source = getDefaultTransferSource(kids)
+		const destination = source
+			? getDefaultTransferDestination(source.account, source.kid, kids)
+			: null
+		if (source) {
+			setKidModalBackground(source.kid.emoji)
+		}
 		transferState = {
-			fromKid: kid,
-			fromAccount: account,
+			fromAccountId: source ? String(source.account.id) : '',
 			toAccountId: destination ? String(destination.id) : '',
 			amount: '',
 			note: '',
 			status: 'idle',
-			error: destination ? null : 'Add another account before transferring.',
+			error: destination
+				? null
+				: 'Add at least two accounts before transferring.',
 		}
 		handle.update()
 		handle.queueTask(() => {
@@ -263,6 +264,23 @@ export function HomeRoute(handle: Handle) {
 		handle.update()
 	}
 
+	function setTransferSource(rawAccountId: string) {
+		if (!transferState) return
+		const source = getTransferAccountOptionById(kids, rawAccountId)
+		transferState.fromAccountId = rawAccountId
+		transferState.toAccountId = source
+			? String(
+					getDefaultTransferDestination(source.account, source.kid, kids)?.id ??
+						'',
+				)
+			: ''
+		transferState.error = null
+		if (source) {
+			setKidModalBackground(source.kid.emoji)
+		}
+		handle.update()
+	}
+
 	async function submitTransaction(direction: 'add' | 'remove') {
 		if (!transactionState || transactionState.status === 'saving') return
 		const cents = parseAmountToCents(transactionState.amount)
@@ -306,18 +324,23 @@ export function HomeRoute(handle: Handle) {
 			handle.update()
 			return
 		}
+		const fromAccountId = Number(transferState.fromAccountId)
+		if (!Number.isInteger(fromAccountId) || fromAccountId < 1) {
+			transferState.error = 'Choose a source account.'
+			handle.update()
+			return
+		}
 		const toAccountId = Number(transferState.toAccountId)
 		if (!Number.isInteger(toAccountId) || toAccountId < 1) {
 			transferState.error = 'Choose a destination account.'
 			handle.update()
 			return
 		}
-		if (toAccountId === transferState.fromAccount.id) {
+		if (toAccountId === fromAccountId) {
 			transferState.error = 'Choose two different accounts.'
 			handle.update()
 			return
 		}
-		const fromAccountId = transferState.fromAccount.id
 		const note = transferState.note
 		transferState.status = 'saving'
 		transferState.error = null
@@ -431,7 +454,7 @@ export function HomeRoute(handle: Handle) {
 									key={account.id}
 									css={{
 										display: 'grid',
-										gridTemplateColumns: 'minmax(0, 1fr) auto',
+										gridTemplateColumns: '1fr',
 										gap: spacing.sm,
 										alignItems: 'stretch',
 										padding: spacing.xs,
@@ -509,35 +532,51 @@ export function HomeRoute(handle: Handle) {
 											{formatCents(account.balanceCents)}
 										</strong>
 									</button>
-									<button
-										type="button"
-										on={{
-											click: (event) => {
-												if (!(event.currentTarget instanceof HTMLButtonElement))
-													return
-												openTransferModal(kid, account, event.currentTarget)
-											},
-										}}
-										css={{
-											...buttonCss,
-											alignSelf: 'stretch',
-											backgroundColor: 'rgba(255,255,255,0.92)',
-											color: colors.text,
-											boxShadow: '0 3px 0 0 rgba(0,0,0,0.2)',
-											'&:active': {
-												transform: 'translateY(3px)',
-												boxShadow: '0 0 0 0 rgba(0,0,0,0.2)',
-											},
-										}}
-									>
-										Transfer
-									</button>
 								</article>
 							)
 						})}
 					</div>
 				</article>
 			))}
+
+			{status === 'ready' ? (
+				<section
+					css={{
+						display: 'grid',
+						gap: spacing.sm,
+						padding: spacing.lg,
+						borderRadius: radius.xl,
+						border: `3px solid ${colors.border}`,
+						backgroundColor: colors.surface,
+						boxShadow: shadows.md,
+						textAlign: 'center',
+					}}
+				>
+					<h2 css={{ margin: 0, color: colors.text }}>Move money around</h2>
+					<p css={{ margin: 0, color: colors.textMuted }}>
+						Transfer between any two accounts. Same-kid accounts are suggested
+						first.
+					</p>
+					<button
+						type="button"
+						disabled={getTransferAccountOptions(kids).length < 2}
+						on={{
+							click: (event) => {
+								if (!(event.currentTarget instanceof HTMLButtonElement)) return
+								openTransferModal(event.currentTarget)
+							},
+						}}
+						css={{
+							...buttonCss,
+							justifySelf: 'center',
+							minWidth: 'min(100%, 18rem)',
+							paddingInline: spacing.lg,
+						}}
+					>
+						Transfer money
+					</button>
+				</section>
+			) : null}
 
 			{transactionState ? (
 				<div
@@ -878,30 +917,42 @@ export function HomeRoute(handle: Handle) {
 							</button>
 						</header>
 
-						<section
-							css={{
-								display: 'grid',
-								gap: spacing.xs,
-								padding: spacing.md,
-								borderRadius: radius.lg,
-								background: getAccountGradientBackground(
-									transferState.fromAccount.colorToken,
-								),
-								color: '#ffffff',
-							}}
-						>
-							<span css={{ fontSize: typography.fontSize.sm, opacity: 0.9 }}>
-								From
+						<label css={{ display: 'grid', gap: spacing.xs }}>
+							<span css={{ color: colors.text }}>From account</span>
+							<select
+								value={transferState.fromAccountId}
+								disabled={getTransferAccountOptions(kids).length === 0}
+								on={{
+									change: (event) => {
+										if (!(event.currentTarget instanceof HTMLSelectElement))
+											return
+										setTransferSource(event.currentTarget.value)
+									},
+								}}
+								css={inputCss}
+							>
+								{getTransferAccountGroups(kids).map((group) => (
+									<optgroup
+										key={group.kid.id}
+										label={`${group.kid.emoji} ${group.kid.name}`}
+									>
+										{group.accounts.map((account) => (
+											<option key={account.id} value={String(account.id)}>
+												{account.name} ({formatCents(account.balanceCents)})
+											</option>
+										))}
+									</optgroup>
+								))}
+							</select>
+							<span
+								css={{
+									color: colors.textMuted,
+									fontSize: typography.fontSize.sm,
+								}}
+							>
+								{getSelectedTransferSourceBalanceLabel(transferState, kids)}
 							</span>
-							<strong css={{ fontSize: typography.fontSize.lg }}>
-								{transferState.fromKid.emoji} {transferState.fromKid.name} ·{' '}
-								{transferState.fromAccount.name}
-							</strong>
-							<span css={{ opacity: 0.9 }}>
-								Current balance:{' '}
-								{formatCents(transferState.fromAccount.balanceCents)}
-							</span>
-						</section>
+						</label>
 
 						<label css={{ display: 'grid', gap: spacing.xs }}>
 							<span css={{ color: colors.text }}>To account</span>
@@ -942,8 +993,10 @@ export function HomeRoute(handle: Handle) {
 									fontSize: typography.fontSize.sm,
 								}}
 							>
-								Accounts for {transferState.fromKid.name} are listed first;
-								other kids are available below.
+								Accounts for{' '}
+								{getSelectedTransferSource(transferState, kids)?.kid.name ??
+									'the selected kid'}{' '}
+								are listed first; other kids are available below.
 							</span>
 						</label>
 
@@ -986,18 +1039,25 @@ export function HomeRoute(handle: Handle) {
 								<button
 									type="button"
 									disabled={
-										Math.abs(transferState.fromAccount.balanceCents) === 0
+										Math.abs(
+											getSelectedTransferSource(transferState, kids)?.account
+												.balanceCents ?? 0,
+										) === 0
 									}
 									on={{
 										click: () =>
 											setTransferAmountFromQuick(
-												Math.abs(transferState!.fromAccount.balanceCents),
+												Math.abs(
+													getSelectedTransferSource(transferState!, kids)
+														?.account.balanceCents ?? 0,
+												),
 											),
 									}}
 									css={quickAmountButtonCss()}
 								>
 									{`Current Total (${formatCents(
-										transferState.fromAccount.balanceCents,
+										getSelectedTransferSource(transferState, kids)?.account
+											.balanceCents ?? 0,
 									)})`}
 								</button>
 								{quickAmounts.map((amount) => (
@@ -1116,9 +1176,60 @@ function quickAmountButtonCss() {
 	}
 }
 
+function getTransferAccountOptions(kids: Array<KidSummary>) {
+	return kids.flatMap((kid) => {
+		return kid.accounts.map((account) => ({ kid, account }))
+	})
+}
+
+function getTransferAccountGroups(kids: Array<KidSummary>) {
+	return kids
+		.map((kid) => ({ kid, accounts: kid.accounts }))
+		.filter((group) => group.accounts.length > 0)
+}
+
+function getDefaultTransferSource(kids: Array<KidSummary>) {
+	return (
+		getTransferAccountOptions(kids).find((option) => {
+			return option.account.balanceCents > 0
+		}) ??
+		getTransferAccountOptions(kids)[0] ??
+		null
+	)
+}
+
+function getTransferAccountOptionById(
+	kids: Array<KidSummary>,
+	rawAccountId: string,
+) {
+	const accountId = Number(rawAccountId)
+	if (!Number.isInteger(accountId)) return null
+	return (
+		getTransferAccountOptions(kids).find((option) => {
+			return option.account.id === accountId
+		}) ?? null
+	)
+}
+
+function getSelectedTransferSource(
+	transferState: TransferState,
+	kids: Array<KidSummary>,
+) {
+	return getTransferAccountOptionById(kids, transferState.fromAccountId)
+}
+
+function getSelectedTransferSourceBalanceLabel(
+	transferState: TransferState,
+	kids: Array<KidSummary>,
+) {
+	const source = getSelectedTransferSource(transferState, kids)
+	if (!source) return 'Choose the account to move money from.'
+	return `Current balance: ${formatCents(source.account.balanceCents)}`
+}
+
 function getDefaultTransferDestination(
-	kid: KidSummary,
 	account: KidAccount,
+	kid: KidSummary,
 	kids: Array<KidSummary>,
 ) {
 	const sameKidAccount = kid.accounts.find((candidate) => {
@@ -1139,19 +1250,21 @@ function getTransferDestinationGroups(
 	transferState: TransferState,
 	kids: Array<KidSummary>,
 ) {
+	const source = getSelectedTransferSource(transferState, kids)
+	if (!source) return []
 	const groups = kids
 		.map((kid) => ({
 			kid,
 			accounts: kid.accounts.filter((account) => {
-				return account.id !== transferState.fromAccount.id
+				return account.id !== source.account.id
 			}),
 		}))
 		.filter((group) => group.accounts.length > 0)
 	const sameKidGroups = groups.filter((group) => {
-		return group.kid.id === transferState.fromKid.id
+		return group.kid.id === source.kid.id
 	})
 	const otherKidGroups = groups.filter((group) => {
-		return group.kid.id !== transferState.fromKid.id
+		return group.kid.id !== source.kid.id
 	})
 	return [...sameKidGroups, ...otherKidGroups]
 }

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -117,6 +117,10 @@ export function HomeRoute(handle: Handle) {
 		opener: HTMLButtonElement,
 	) {
 		clearCloseModalTimeout()
+		clearTransferCloseModalTimeout()
+		transferState = null
+		transferModalClosing = false
+		transferModalOpener = null
 		removeTransactionModalStyles()
 		setKidModalBackground(kid.emoji)
 		transactionModalOpener = opener
@@ -141,6 +145,11 @@ export function HomeRoute(handle: Handle) {
 
 	function openTransferModal(opener: HTMLButtonElement) {
 		clearTransferCloseModalTimeout()
+		clearCloseModalTimeout()
+		transactionState = null
+		transactionModalClosing = false
+		transactionModalOpener = null
+		removeTransactionModalStyles()
 		transferModalOpener = opener
 		transferModalClosing = false
 		const source = getDefaultTransferSource(kids)
@@ -723,17 +732,7 @@ export function HomeRoute(handle: Handle) {
 												Math.abs(transactionState!.account.balanceCents),
 											),
 									}}
-									css={{
-										...buttonCss,
-										backgroundColor: colors.surface,
-										color: colors.text,
-										border: `2px solid ${colors.border}`,
-										boxShadow: `0 2px 0 0 ${colors.border}`,
-										'&:active': {
-											transform: 'translateY(2px)',
-											boxShadow: `0 0 0 0 ${colors.border}`,
-										},
-									}}
+									css={quickAmountButtonCss()}
 								>
 									{`Current Total (${formatCents(
 										transactionState.account.balanceCents,
@@ -744,17 +743,7 @@ export function HomeRoute(handle: Handle) {
 										key={amount}
 										type="button"
 										on={{ click: () => setTransactionAmountFromQuick(amount) }}
-										css={{
-											...buttonCss,
-											backgroundColor: colors.surface,
-											color: colors.text,
-											border: `2px solid ${colors.border}`,
-											boxShadow: `0 2px 0 0 ${colors.border}`,
-											'&:active': {
-												transform: 'translateY(2px)',
-												boxShadow: `0 0 0 0 ${colors.border}`,
-											},
-										}}
+										css={quickAmountButtonCss()}
 									>
 										{formatCents(amount)}
 									</button>
@@ -1039,25 +1028,18 @@ export function HomeRoute(handle: Handle) {
 								<button
 									type="button"
 									disabled={
-										Math.abs(
-											getSelectedTransferSource(transferState, kids)?.account
-												.balanceCents ?? 0,
-										) === 0
+										getTransferAvailableBalanceCents(transferState, kids) === 0
 									}
 									on={{
 										click: () =>
 											setTransferAmountFromQuick(
-												Math.abs(
-													getSelectedTransferSource(transferState!, kids)
-														?.account.balanceCents ?? 0,
-												),
+												getTransferAvailableBalanceCents(transferState!, kids),
 											),
 									}}
 									css={quickAmountButtonCss()}
 								>
 									{`Current Total (${formatCents(
-										getSelectedTransferSource(transferState, kids)?.account
-											.balanceCents ?? 0,
+										getTransferAvailableBalanceCents(transferState, kids),
 									)})`}
 								</button>
 								{quickAmounts.map((amount) => (
@@ -1225,6 +1207,16 @@ function getSelectedTransferSourceBalanceLabel(
 	const source = getSelectedTransferSource(transferState, kids)
 	if (!source) return 'Choose the account to move money from.'
 	return `Current balance: ${formatCents(source.account.balanceCents)}`
+}
+
+function getTransferAvailableBalanceCents(
+	transferState: TransferState,
+	kids: Array<KidSummary>,
+) {
+	return Math.max(
+		getSelectedTransferSource(transferState, kids)?.account.balanceCents ?? 0,
+		0,
+	)
 }
 
 function getDefaultTransferDestination(

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -1,6 +1,7 @@
 import { type Handle } from 'remix/component'
 import {
 	createTransaction,
+	createTransfer,
 	fetchDashboard,
 	type KidAccount,
 	type KidSummary,
@@ -39,6 +40,16 @@ type TransactionState = {
 	warning: string | null
 }
 
+type TransferState = {
+	fromKid: KidSummary
+	fromAccount: KidAccount
+	toAccountId: string
+	amount: string
+	note: string
+	status: 'idle' | 'saving'
+	error: string | null
+}
+
 const modalCloseAnimationDurationMs = 220
 
 function getNextMonthlyInterestPayoutDate(from = new Date()) {
@@ -75,6 +86,10 @@ export function HomeRoute(handle: Handle) {
 	let transactionModalOpener: HTMLButtonElement | null = null
 	let transactionModalClosing = false
 	let closeModalTimeoutId: number | null = null
+	let transferState: TransferState | null = null
+	let transferModalOpener: HTMLButtonElement | null = null
+	let transferModalClosing = false
+	let closeTransferModalTimeoutId: number | null = null
 
 	function removeTransactionModalStyles() {
 		if (typeof document === 'undefined') return
@@ -89,6 +104,12 @@ export function HomeRoute(handle: Handle) {
 		if (closeModalTimeoutId === null) return
 		window.clearTimeout(closeModalTimeoutId)
 		closeModalTimeoutId = null
+	}
+
+	function clearTransferCloseModalTimeout() {
+		if (closeTransferModalTimeoutId === null) return
+		window.clearTimeout(closeTransferModalTimeoutId)
+		closeTransferModalTimeoutId = null
 	}
 
 	function openTransactionModal(
@@ -119,6 +140,34 @@ export function HomeRoute(handle: Handle) {
 		})
 	}
 
+	function openTransferModal(
+		kid: KidSummary,
+		account: KidAccount,
+		opener: HTMLButtonElement,
+	) {
+		clearTransferCloseModalTimeout()
+		setKidModalBackground(kid.emoji)
+		transferModalOpener = opener
+		transferModalClosing = false
+		const destination = getDefaultTransferDestination(kid, account, kids)
+		transferState = {
+			fromKid: kid,
+			fromAccount: account,
+			toAccountId: destination ? String(destination.id) : '',
+			amount: '',
+			note: '',
+			status: 'idle',
+			error: destination ? null : 'Add another account before transferring.',
+		}
+		handle.update()
+		handle.queueTask(() => {
+			const closeButton = document.getElementById('transfer-modal-close')
+			if (closeButton instanceof HTMLButtonElement) {
+				closeButton.focus()
+			}
+		})
+	}
+
 	function closeTransactionModal() {
 		if (!transactionState || transactionModalClosing) return
 		const opener = transactionModalOpener
@@ -140,8 +189,32 @@ export function HomeRoute(handle: Handle) {
 		}, modalCloseAnimationDurationMs)
 	}
 
+	function closeTransferModal() {
+		if (!transferState || transferModalClosing) return
+		const opener = transferModalOpener
+		transferModalOpener = null
+		transferModalClosing = true
+		handle.update()
+		closeTransferModalTimeoutId = window.setTimeout(() => {
+			transferState = null
+			transferModalClosing = false
+			closeTransferModalTimeoutId = null
+			clearKidModalBackground()
+			handle.update()
+			if (opener?.isConnected) {
+				handle.queueTask(() => {
+					opener.focus()
+				})
+			}
+		}, modalCloseAnimationDurationMs)
+	}
+
 	function handleTransactionModalKeydown(event: KeyboardEvent) {
 		handleModalKeydown(event, closeTransactionModal)
+	}
+
+	function handleTransferModalKeydown(event: KeyboardEvent) {
+		handleModalKeydown(event, closeTransferModal)
 	}
 
 	async function refreshDashboard() {
@@ -170,6 +243,7 @@ export function HomeRoute(handle: Handle) {
 	handle.queueTask(() => {
 		return () => {
 			clearCloseModalTimeout()
+			clearTransferCloseModalTimeout()
 			removeTransactionModalStyles()
 			clearKidModalBackground()
 		}
@@ -179,6 +253,13 @@ export function HomeRoute(handle: Handle) {
 		if (!transactionState) return
 		transactionState.amount = (cents / 100).toFixed(2)
 		transactionState.error = null
+		handle.update()
+	}
+
+	function setTransferAmountFromQuick(cents: number) {
+		if (!transferState) return
+		transferState.amount = (cents / 100).toFixed(2)
+		transferState.error = null
 		handle.update()
 	}
 
@@ -213,6 +294,49 @@ export function HomeRoute(handle: Handle) {
 		} catch (error) {
 			window.alert(
 				error instanceof Error ? error.message : 'Could not save transaction.',
+			)
+		}
+	}
+
+	async function submitTransfer() {
+		if (!transferState || transferState.status === 'saving') return
+		const cents = parseAmountToCents(transferState.amount)
+		if (cents === null || cents <= 0) {
+			transferState.error = 'Enter an amount greater than zero.'
+			handle.update()
+			return
+		}
+		const toAccountId = Number(transferState.toAccountId)
+		if (!Number.isInteger(toAccountId) || toAccountId < 1) {
+			transferState.error = 'Choose a destination account.'
+			handle.update()
+			return
+		}
+		if (toAccountId === transferState.fromAccount.id) {
+			transferState.error = 'Choose two different accounts.'
+			handle.update()
+			return
+		}
+		const fromAccountId = transferState.fromAccount.id
+		const note = transferState.note
+		transferState.status = 'saving'
+		transferState.error = null
+		handle.update()
+		closeTransferModal()
+		try {
+			const result = await createTransfer({
+				fromAccountId,
+				toAccountId,
+				amountCents: cents,
+				note,
+			})
+			if (result.result.warning) {
+				window.alert(result.result.warning)
+			}
+			await refreshDashboard()
+		} catch (error) {
+			window.alert(
+				error instanceof Error ? error.message : 'Could not save transfer.',
 			)
 		}
 	}
@@ -303,68 +427,112 @@ export function HomeRoute(handle: Handle) {
 						{kid.accounts.map((account) => {
 							const interestPreviewText = getInterestPreviewText(account)
 							return (
-								<button
+								<article
 									key={account.id}
-									type="button"
-									on={{
-										click: (event) => {
-											if (!(event.currentTarget instanceof HTMLButtonElement))
-												return
-											openTransactionModal(kid, account, event.currentTarget)
-										},
-									}}
 									css={{
-										display: 'flex',
-										justifyContent: 'space-between',
-										alignItems: 'center',
+										display: 'grid',
+										gridTemplateColumns: 'minmax(0, 1fr) auto',
 										gap: spacing.sm,
-										padding: spacing.md,
+										alignItems: 'stretch',
+										padding: spacing.xs,
 										borderRadius: radius.lg,
-										border: 'none',
 										background: getAccountGradientBackground(
 											account.colorToken,
 										),
 										color: '#ffffff',
-										cursor: 'pointer',
 										boxShadow: `0 4px 0 0 rgba(0,0,0,0.2)`,
-										transition: `all ${transitions.fast}`,
-										'&:hover': { filter: 'brightness(1.1)' },
-										'&:active': {
-											transform: 'translateY(4px)',
-											boxShadow: '0 0 0 0 rgba(0,0,0,0.2)',
+										[mq.mobile]: {
+											gridTemplateColumns: '1fr',
 										},
 									}}
 								>
-									<span
+									<button
+										type="button"
+										on={{
+											click: (event) => {
+												if (!(event.currentTarget instanceof HTMLButtonElement))
+													return
+												openTransactionModal(kid, account, event.currentTarget)
+											},
+										}}
 										css={{
-											display: 'grid',
-											gap: 2,
+											display: 'flex',
+											justifyContent: 'space-between',
+											alignItems: 'center',
+											gap: spacing.sm,
+											minWidth: 0,
+											padding: spacing.sm,
+											border: 'none',
+											borderRadius: radius.md,
+											background: 'transparent',
+											color: 'inherit',
+											cursor: 'pointer',
 											textAlign: 'left',
-											fontWeight: typography.fontWeight.semibold,
+											transition: `background-color ${transitions.fast}`,
+											'&:hover': {
+												backgroundColor: 'rgba(255,255,255,0.14)',
+											},
 										}}
 									>
-										{account.name}
 										<span
-											css={{ fontSize: typography.fontSize.sm, opacity: 0.9 }}
+											css={{
+												display: 'grid',
+												gap: 2,
+												minWidth: 0,
+												fontWeight: typography.fontWeight.semibold,
+											}}
 										>
-											Tap to add or remove money
-										</span>
-										{interestPreviewText ? (
+											{account.name}
 											<span
-												css={{
-													fontSize: typography.fontSize.sm,
-													fontWeight: typography.fontWeight.normal,
-													opacity: 0.9,
-												}}
+												css={{ fontSize: typography.fontSize.sm, opacity: 0.9 }}
 											>
-												{interestPreviewText}
+												Tap to add or remove money
 											</span>
-										) : null}
-									</span>
-									<strong css={{ fontSize: typography.fontSize.lg }}>
-										{formatCents(account.balanceCents)}
-									</strong>
-								</button>
+											{interestPreviewText ? (
+												<span
+													css={{
+														fontSize: typography.fontSize.sm,
+														fontWeight: typography.fontWeight.normal,
+														opacity: 0.9,
+													}}
+												>
+													{interestPreviewText}
+												</span>
+											) : null}
+										</span>
+										<strong
+											css={{
+												flexShrink: 0,
+												fontSize: typography.fontSize.lg,
+											}}
+										>
+											{formatCents(account.balanceCents)}
+										</strong>
+									</button>
+									<button
+										type="button"
+										on={{
+											click: (event) => {
+												if (!(event.currentTarget instanceof HTMLButtonElement))
+													return
+												openTransferModal(kid, account, event.currentTarget)
+											},
+										}}
+										css={{
+											...buttonCss,
+											alignSelf: 'stretch',
+											backgroundColor: 'rgba(255,255,255,0.92)',
+											color: colors.text,
+											boxShadow: '0 3px 0 0 rgba(0,0,0,0.2)',
+											'&:active': {
+												transform: 'translateY(3px)',
+												boxShadow: '0 0 0 0 rgba(0,0,0,0.2)',
+											},
+										}}
+									>
+										Transfer
+									</button>
+								</article>
 							)
 						})}
 					</div>
@@ -620,6 +788,283 @@ export function HomeRoute(handle: Handle) {
 					</section>
 				</div>
 			) : null}
+
+			{transferState ? (
+				<div
+					on={{
+						click: (event) => {
+							if (event.target === event.currentTarget) {
+								closeTransferModal()
+							}
+						},
+					}}
+					css={{
+						position: 'fixed',
+						inset: 0,
+						backgroundColor: 'rgba(0, 0, 0, 0.45)',
+						display: 'grid',
+						placeItems: 'center',
+						padding: spacing.md,
+						zIndex: 1000,
+						pointerEvents: transferModalClosing ? 'none' : 'auto',
+						animation: transferModalClosing
+							? `modal-backdrop-out ${modalCloseAnimationDurationMs}ms ease-in forwards`
+							: 'modal-backdrop-in 180ms ease-out forwards',
+						[mq.mobile]: {
+							padding: 0,
+							placeItems: 'stretch',
+						},
+					}}
+				>
+					<section
+						role="dialog"
+						aria-modal="true"
+						aria-labelledby="transfer-modal-title"
+						aria-describedby="transfer-modal-description"
+						on={{ keydown: handleTransferModalKeydown }}
+						css={{
+							width: 'min(34rem, 100%)',
+							maxHeight: 'calc(100dvh - 2 * var(--spacing-md))',
+							overflow: 'auto',
+							display: 'grid',
+							gap: spacing.md,
+							padding: spacing.lg,
+							fontFamily: typography.fontFamily,
+							borderRadius: radius.xl,
+							border: `3px solid ${colors.border}`,
+							backgroundColor: colors.surface,
+							boxShadow: shadows.lg,
+							animation: transferModalClosing
+								? `modal-close ${modalCloseAnimationDurationMs}ms ease-in forwards`
+								: 'modal-pop 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards',
+							[mq.mobile]: {
+								width: '100%',
+								maxHeight: '100dvh',
+								minHeight: '100dvh',
+								borderRadius: 0,
+								border: 'none',
+								gap: spacing.sm,
+								padding: spacing.md,
+							},
+						}}
+					>
+						<header css={{ display: 'flex', justifyContent: 'space-between' }}>
+							<div>
+								<h3
+									id="transfer-modal-title"
+									css={{ margin: 0, color: colors.text }}
+								>
+									Transfer money
+								</h3>
+								<p
+									id="transfer-modal-description"
+									css={{ margin: 0, color: colors.textMuted }}
+								>
+									Move any amount from one account to another.
+								</p>
+							</div>
+							<button
+								id="transfer-modal-close"
+								type="button"
+								on={{ click: closeTransferModal }}
+								css={{
+									border: 'none',
+									background: 'transparent',
+									color: colors.textMuted,
+									cursor: 'pointer',
+								}}
+							>
+								Close
+							</button>
+						</header>
+
+						<section
+							css={{
+								display: 'grid',
+								gap: spacing.xs,
+								padding: spacing.md,
+								borderRadius: radius.lg,
+								background: getAccountGradientBackground(
+									transferState.fromAccount.colorToken,
+								),
+								color: '#ffffff',
+							}}
+						>
+							<span css={{ fontSize: typography.fontSize.sm, opacity: 0.9 }}>
+								From
+							</span>
+							<strong css={{ fontSize: typography.fontSize.lg }}>
+								{transferState.fromKid.emoji} {transferState.fromKid.name} ·{' '}
+								{transferState.fromAccount.name}
+							</strong>
+							<span css={{ opacity: 0.9 }}>
+								Current balance:{' '}
+								{formatCents(transferState.fromAccount.balanceCents)}
+							</span>
+						</section>
+
+						<label css={{ display: 'grid', gap: spacing.xs }}>
+							<span css={{ color: colors.text }}>To account</span>
+							<select
+								value={transferState.toAccountId}
+								disabled={
+									getTransferDestinationGroups(transferState, kids).length === 0
+								}
+								on={{
+									change: (event) => {
+										if (!(event.currentTarget instanceof HTMLSelectElement))
+											return
+										transferState!.toAccountId = event.currentTarget.value
+										transferState!.error = null
+										handle.update()
+									},
+								}}
+								css={inputCss}
+							>
+								{getTransferDestinationGroups(transferState, kids).map(
+									(group) => (
+										<optgroup
+											key={group.kid.id}
+											label={`${group.kid.emoji} ${group.kid.name}`}
+										>
+											{group.accounts.map((account) => (
+												<option key={account.id} value={String(account.id)}>
+													{account.name} ({formatCents(account.balanceCents)})
+												</option>
+											))}
+										</optgroup>
+									),
+								)}
+							</select>
+							<span
+								css={{
+									color: colors.textMuted,
+									fontSize: typography.fontSize.sm,
+								}}
+							>
+								Accounts for {transferState.fromKid.name} are listed first;
+								other kids are available below.
+							</span>
+						</label>
+
+						<label css={{ display: 'grid', gap: spacing.xs }}>
+							<span css={{ color: colors.text }}>Amount</span>
+							<input
+								type="number"
+								min="0"
+								step="0.01"
+								value={transferState.amount}
+								on={{
+									input: (event) => {
+										if (!(event.currentTarget instanceof HTMLInputElement))
+											return
+										transferState!.amount = event.currentTarget.value
+										transferState!.error = null
+										handle.update()
+									},
+								}}
+								css={inputCss}
+							/>
+						</label>
+
+						<div css={{ display: 'grid', gap: spacing.xs }}>
+							<span
+								css={{
+									color: colors.textMuted,
+									fontSize: typography.fontSize.sm,
+								}}
+							>
+								Quick amounts
+							</span>
+							<div
+								css={{
+									display: 'grid',
+									gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+									gap: spacing.xs,
+								}}
+							>
+								<button
+									type="button"
+									disabled={
+										Math.abs(transferState.fromAccount.balanceCents) === 0
+									}
+									on={{
+										click: () =>
+											setTransferAmountFromQuick(
+												Math.abs(transferState!.fromAccount.balanceCents),
+											),
+									}}
+									css={quickAmountButtonCss()}
+								>
+									{`Current Total (${formatCents(
+										transferState.fromAccount.balanceCents,
+									)})`}
+								</button>
+								{quickAmounts.map((amount) => (
+									<button
+										key={amount}
+										type="button"
+										on={{ click: () => setTransferAmountFromQuick(amount) }}
+										css={quickAmountButtonCss()}
+									>
+										{formatCents(amount)}
+									</button>
+								))}
+							</div>
+						</div>
+
+						<label css={{ display: 'grid', gap: spacing.xs }}>
+							<span css={{ color: colors.text }}>Note (optional)</span>
+							<input
+								type="text"
+								value={transferState.note}
+								on={{
+									input: (event) => {
+										if (!(event.currentTarget instanceof HTMLInputElement))
+											return
+										transferState!.note = event.currentTarget.value
+										handle.update()
+									},
+								}}
+								css={inputCss}
+							/>
+						</label>
+
+						{transferState.error ? (
+							<p css={{ margin: 0, color: colors.error }}>
+								{transferState.error}
+							</p>
+						) : null}
+
+						<div
+							css={{
+								display: 'grid',
+								gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+								gap: spacing.sm,
+							}}
+						>
+							<button
+								type="button"
+								on={{ click: closeTransferModal }}
+								css={{
+									...modalButtonCss(colors.surface, colors.text, colors.border),
+									border: `2px solid ${colors.border}`,
+								}}
+							>
+								Cancel
+							</button>
+							<button
+								type="button"
+								disabled={transferState.status === 'saving'}
+								on={{ click: () => void submitTransfer() }}
+								css={modalButtonCss('#bfdbfe', '#172554', '#2563eb')}
+							>
+								Transfer
+							</button>
+						</div>
+					</section>
+				</div>
+			) : null}
 		</section>
 	)
 }
@@ -655,6 +1100,60 @@ function modalButtonCss(
 			boxShadow: `0 0 0 0 ${activeShadow}`,
 		},
 	}
+}
+
+function quickAmountButtonCss() {
+	return {
+		...buttonCss,
+		backgroundColor: colors.surface,
+		color: colors.text,
+		border: `2px solid ${colors.border}`,
+		boxShadow: `0 2px 0 0 ${colors.border}`,
+		'&:active': {
+			transform: 'translateY(2px)',
+			boxShadow: `0 0 0 0 ${colors.border}`,
+		},
+	}
+}
+
+function getDefaultTransferDestination(
+	kid: KidSummary,
+	account: KidAccount,
+	kids: Array<KidSummary>,
+) {
+	const sameKidAccount = kid.accounts.find((candidate) => {
+		return candidate.id !== account.id
+	})
+	if (sameKidAccount) return sameKidAccount
+	for (const candidateKid of kids) {
+		if (candidateKid.id === kid.id) continue
+		const destination = candidateKid.accounts.find((candidate) => {
+			return candidate.id !== account.id
+		})
+		if (destination) return destination
+	}
+	return null
+}
+
+function getTransferDestinationGroups(
+	transferState: TransferState,
+	kids: Array<KidSummary>,
+) {
+	const groups = kids
+		.map((kid) => ({
+			kid,
+			accounts: kid.accounts.filter((account) => {
+				return account.id !== transferState.fromAccount.id
+			}),
+		}))
+		.filter((group) => group.accounts.length > 0)
+	const sameKidGroups = groups.filter((group) => {
+		return group.kid.id === transferState.fromKid.id
+	})
+	const otherKidGroups = groups.filter((group) => {
+		return group.kid.id !== transferState.fromKid.id
+	})
+	return [...sameKidGroups, ...otherKidGroups]
 }
 
 function LoggedOutHome() {

--- a/e2e/ledger.spec.ts
+++ b/e2e/ledger.spec.ts
@@ -109,8 +109,12 @@ test('parent can transfer money between same-kid and cross-kid accounts', async 
 
 	await page.getByRole('button', { name: 'Transfer money' }).click()
 	const modal = page.getByRole('dialog', { name: 'Transfer money' })
-	await expect(modal.getByLabel('From account')).toContainText(accountName)
-	await expect(modal.getByLabel('To account')).toContainText(savingsName)
+	await expect(
+		modal.getByLabel('From account').locator('option:checked'),
+	).toContainText(accountName)
+	await expect(
+		modal.getByLabel('To account').locator('option:checked'),
+	).toContainText(savingsName)
 	await expect(
 		modal.getByText(`Accounts for ${kidName} are listed first`),
 	).toBeVisible()

--- a/e2e/ledger.spec.ts
+++ b/e2e/ledger.spec.ts
@@ -107,12 +107,9 @@ test('parent can transfer money between same-kid and cross-kid accounts', async 
 	await page.getByRole('button', { name: 'Add' }).last().click()
 	await expect(page.getByText('Family Total:')).toContainText('$12.00')
 
-	await page
-		.getByRole('button', { name: new RegExp(accountName) })
-		.locator('xpath=ancestor::article[1]')
-		.getByRole('button', { name: 'Transfer' })
-		.click()
+	await page.getByRole('button', { name: 'Transfer money' }).click()
 	const modal = page.getByRole('dialog', { name: 'Transfer money' })
+	await expect(modal.getByLabel('From account')).toContainText(accountName)
 	await expect(modal.getByLabel('To account')).toContainText(savingsName)
 	await expect(
 		modal.getByText(`Accounts for ${kidName} are listed first`),
@@ -127,11 +124,10 @@ test('parent can transfer money between same-kid and cross-kid accounts', async 
 		page.getByRole('button', { name: new RegExp(savingsName) }),
 	).toContainText('$5.50')
 
-	await page
-		.getByRole('button', { name: new RegExp(savingsName) })
-		.locator('xpath=ancestor::article[1]')
-		.getByRole('button', { name: 'Transfer' })
-		.click()
+	await page.getByRole('button', { name: 'Transfer money' }).click()
+	await modal
+		.getByLabel('From account')
+		.selectOption({ label: `${savingsName} ($5.50)` })
 	await modal
 		.getByLabel('To account')
 		.selectOption({ label: `${otherAccountName} ($0.00)` })

--- a/e2e/ledger.spec.ts
+++ b/e2e/ledger.spec.ts
@@ -1,4 +1,9 @@
-import { createKidWithAccount, expect, test } from './playwright-utils.ts'
+import {
+	addAccountToKidCard,
+	createKidWithAccount,
+	expect,
+	test,
+} from './playwright-utils.ts'
 
 test('parent can complete first kid/account/transaction flow', async ({
 	page,
@@ -74,4 +79,70 @@ test('home shows monthly interest preview for accounts with APY', async ({
 	await expect(accountButton).toContainText('12% APY')
 	await expect(accountButton).toContainText('estimated payout $0.28')
 	await expect(accountButton).toContainText(/on [A-Z][a-z]{2} \d{1,2}/)
+})
+
+test('parent can transfer money between same-kid and cross-kid accounts', async ({
+	page,
+	login,
+}) => {
+	await login()
+	const kidName = `Kid-${crypto.randomUUID().slice(0, 6)}`
+	const accountName = `Spending-${crypto.randomUUID().slice(0, 6)}`
+	const { kidCard } = await createKidWithAccount(page, {
+		kidName,
+		accountName,
+	})
+	const savingsName = await addAccountToKidCard(kidCard, {
+		accountName: `Savings-${crypto.randomUUID().slice(0, 6)}`,
+	})
+	const otherAccountName = `Giving-${crypto.randomUUID().slice(0, 6)}`
+	await createKidWithAccount(page, {
+		kidName: `Other-${crypto.randomUUID().slice(0, 6)}`,
+		accountName: otherAccountName,
+	})
+
+	await page.goto('/')
+	await page.getByRole('button', { name: new RegExp(accountName) }).click()
+	await page.getByLabel('Amount').fill('12.00')
+	await page.getByRole('button', { name: 'Add' }).last().click()
+	await expect(page.getByText('Family Total:')).toContainText('$12.00')
+
+	await page
+		.getByRole('button', { name: new RegExp(accountName) })
+		.locator('xpath=ancestor::article[1]')
+		.getByRole('button', { name: 'Transfer' })
+		.click()
+	const modal = page.getByRole('dialog', { name: 'Transfer money' })
+	await expect(modal.getByLabel('To account')).toContainText(savingsName)
+	await expect(
+		modal.getByText(`Accounts for ${kidName} are listed first`),
+	).toBeVisible()
+	await modal.getByLabel('Amount').fill('5.50')
+	await modal.getByRole('button', { name: 'Transfer' }).click()
+
+	await expect(
+		page.getByRole('button', { name: new RegExp(accountName) }),
+	).toContainText('$6.50')
+	await expect(
+		page.getByRole('button', { name: new RegExp(savingsName) }),
+	).toContainText('$5.50')
+
+	await page
+		.getByRole('button', { name: new RegExp(savingsName) })
+		.locator('xpath=ancestor::article[1]')
+		.getByRole('button', { name: 'Transfer' })
+		.click()
+	await modal
+		.getByLabel('To account')
+		.selectOption({ label: `${otherAccountName} ($0.00)` })
+	await modal.getByLabel('Amount').fill('2.25')
+	await modal.getByRole('button', { name: 'Transfer' }).click()
+
+	await expect(
+		page.getByRole('button', { name: new RegExp(savingsName) }),
+	).toContainText('$3.25')
+	await expect(
+		page.getByRole('button', { name: new RegExp(otherAccountName) }),
+	).toContainText('$2.25')
+	await expect(page.getByText('Family Total:')).toContainText('$12.00')
 })

--- a/server/handlers/ledger-api.ts
+++ b/server/handlers/ledger-api.ts
@@ -66,6 +66,13 @@ const createTransactionSchema = object({
 	note: optional(string()),
 })
 
+const createTransferSchema = object({
+	fromAccountId: number(),
+	toAccountId: number(),
+	amountCents: number(),
+	note: optional(string()),
+})
+
 const setQuickAmountsSchema = object({
 	amounts: array(number()),
 })
@@ -340,6 +347,17 @@ export function createTransactionCreateHandler(appEnv: AppEnv) {
 	}) satisfies BuildAction<
 		typeof routes.apiTransactionsCreate.method,
 		typeof routes.apiTransactionsCreate.pattern
+	>
+}
+
+export function createTransferCreateHandler(appEnv: AppEnv) {
+	return createLedgerMutationHandler(appEnv, {
+		schema: createTransferSchema,
+		run: (service, input) => service.transferBetweenAccounts(input),
+		mapResponse: (result) => ({ result }),
+	}) satisfies BuildAction<
+		typeof routes.apiTransfersCreate.method,
+		typeof routes.apiTransfersCreate.pattern
 	>
 }
 

--- a/server/ledger/ledger-service.ts
+++ b/server/ledger/ledger-service.ts
@@ -373,6 +373,64 @@ export class LedgerService {
 		}
 	}
 
+	async transferBetweenAccounts(input: {
+		fromAccountId: number
+		toAccountId: number
+		amountCents: number
+		note?: string
+	}) {
+		if (!Number.isInteger(input.amountCents) || input.amountCents <= 0) {
+			throw new Error('amountCents must be a positive integer.')
+		}
+		if (input.fromAccountId === input.toAccountId) {
+			throw new Error('Choose two different accounts for a transfer.')
+		}
+		const fromAccount = await this.#requireAccount(input.fromAccountId)
+		const toAccount = await this.#requireAccount(input.toAccountId)
+		if (fromAccount.isArchived || toAccount.isArchived) {
+			throw new Error('Archived accounts cannot be used for transfers.')
+		}
+		const note = (input.note ?? '').trim()
+		const fromNote = note
+			? `Transfer to ${toAccount.kidName} - ${toAccount.name}: ${note}`
+			: `Transfer to ${toAccount.kidName} - ${toAccount.name}`
+		const toNote = note
+			? `Transfer from ${fromAccount.kidName} - ${fromAccount.name}: ${note}`
+			: `Transfer from ${fromAccount.kidName} - ${fromAccount.name}`
+
+		await this.#run(
+			`INSERT INTO transactions (household_id, kid_id, account_id, amount_cents, note, source_type)
+			 VALUES (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)`,
+			[
+				fromAccount.householdId,
+				fromAccount.kidId,
+				fromAccount.id,
+				-Math.abs(input.amountCents),
+				fromNote,
+				'transfer',
+				toAccount.householdId,
+				toAccount.kidId,
+				toAccount.id,
+				Math.abs(input.amountCents),
+				toNote,
+				'transfer',
+			],
+		)
+
+		const fromBalance = await this.#getAccountBalance(fromAccount.id)
+		const toBalance = await this.#getAccountBalance(toAccount.id)
+		return {
+			fromAccountId: fromAccount.id,
+			fromBalanceCents: fromBalance,
+			toAccountId: toAccount.id,
+			toBalanceCents: toBalance,
+			warning:
+				fromBalance < 0
+					? 'The source account balance is negative after this transfer.'
+					: null,
+		}
+	}
+
 	async listTransactions(input: {
 		kidId?: number
 		accountId?: number
@@ -883,8 +941,10 @@ export class LedgerService {
 			`SELECT
 				a.id,
 				a.kid_id,
+				a.name,
 				a.apy_basis_points,
 				a.is_archived,
+				k.name AS kid_name,
 				k.household_id
 			 FROM accounts a
 			 INNER JOIN kids k ON k.id = a.kid_id
@@ -902,6 +962,8 @@ export class LedgerService {
 		return {
 			id: getNumber(row.id),
 			kidId: getNumber(row.kid_id),
+			name: getString(row.name),
+			kidName: getString(row.kid_name),
 			householdId,
 			apyBasisPoints: getNumber(row.apy_basis_points),
 			isArchived: getBoolean(row.is_archived),

--- a/server/router.ts
+++ b/server/router.ts
@@ -24,6 +24,7 @@ import {
 	createLedgerSettingsHandler,
 	createQuickAmountsSetHandler,
 	createTransactionCreateHandler,
+	createTransferCreateHandler,
 } from './handlers/ledger-api.ts'
 import { home } from './handlers/home.ts'
 import { login } from './handlers/login.ts'
@@ -94,6 +95,7 @@ export function createAppRouter(appEnv: AppEnv) {
 		routes.apiTransactionsCreate,
 		createTransactionCreateHandler(appEnv),
 	)
+	router.map(routes.apiTransfersCreate, createTransferCreateHandler(appEnv))
 	router.map(routes.apiQuickAmountsSet, createQuickAmountsSetHandler(appEnv))
 	router.map(routes.apiExportJson, createExportJsonHandler(appEnv))
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -36,6 +36,7 @@ export const routes = route({
 	apiAccountsUnarchive: post('/ledger/accounts/unarchive'),
 	apiAccountsDelete: post('/ledger/accounts/delete'),
 	apiTransactionsCreate: post('/ledger/transactions/create'),
+	apiTransfersCreate: post('/ledger/transfers/create'),
 	apiQuickAmountsSet: post('/ledger/quick-amounts/set'),
 	apiExportJson: '/ledger/export/json',
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a transfer API endpoint that writes paired debit and credit ledger transactions.
- Add one bottom-of-home transfer action that opens a mobile-friendly modal with From and To account selectors.
- Bias destination choices toward accounts under the selected source kid while still allowing cross-kid transfers.
- Cover same-kid and cross-kid transfers through the bottom button in Playwright.
- Address PR review comments around modal close timing, transfer quick-fill behavior, shared quick-amount styling, and selected-default assertions.

## Walkthrough
<a href="https://cursor.com/agents/bc-5f3f9e08-0bb4-4f32-bf4c-c65a4f581663/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftransfer-bottom-flow-walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-b41ced2e-3a28-4757-992f-7eb88073d175" alt="transfer-bottom-flow-walkthrough.mp4" /></a>
![Desktop home with bottom transfer button](https://cursor.com/artifacts/c/art-876941eb-9fab-4c52-a312-743d61cf0fc7)
![Desktop transfer modal with source and destination selectors](https://cursor.com/artifacts/c/art-eab915c1-f460-429a-a305-be3ae3fb1cc4)
![Mobile transfer modal](https://cursor.com/artifacts/c/art-a38603e5-b50e-4ddf-9621-66d444a9de26)

## Testing
- `cp .env.test .env && bun run migrate:local`
- `PLAYWRIGHT_PORT=8791 bun run test:e2e -- e2e/ledger.spec.ts`
- `PLAYWRIGHT_PORT=8792 bun run validate`
- `PLAYWRIGHT_PORT=8794 bun run test:e2e -- e2e/ledger.spec.ts`
- `PLAYWRIGHT_PORT=8795 bun run validate`
- Browser walkthrough captured with local Playwright against `http://localhost:8793`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f3f9e08-0bb4-4f32-bf4c-c65a4f581663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f3f9e08-0bb4-4f32-bf4c-c65a4f581663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transfer money via a top-level "Transfer money" modal with source/destination selectors, quick-fill amount buttons, optional note, and Escape-to-close/focus behaviors.
  * Transfers support same-child and cross-child accounts; balances refresh immediately and server warnings surface to the user.

* **Tests**
  * Added end-to-end test covering same-kid and cross-kid transfer flows and balance updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kentcdodds/kids-ledger/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->