### PR TITLE
Add SSR hydration and client routing flow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -130,6 +130,7 @@ jobs:
         id: resources
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
         run: |
           set -euo pipefail
@@ -138,6 +139,7 @@ jobs:
       - name: 🗄️ Apply D1 Migrations (preview)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_ENV: preview
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
         run:
@@ -147,6 +149,7 @@ jobs:
       - name: 🌱 Seed preview test data
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_ENV: preview
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
         run: bun tools/seed-test-data.ts --remote --config "$WRANGLER_CONFIG"
@@ -155,6 +158,7 @@ jobs:
         id: deploy_mocks
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
           D1_DATABASE_NAME: ${{ steps.resources.outputs.d1_database_name }}
           D1_DATABASE_ID: ${{ steps.resources.outputs.d1_database_id }}
@@ -233,6 +237,7 @@ jobs:
       - name: 🔐 Sync preview app Worker secrets (bulk)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
           OVERRIDES_FILE: ${{ steps.deploy_mocks.outputs.overrides_file }}
         run: |
@@ -253,6 +258,7 @@ jobs:
         id: deploy_preview
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_ENV: preview
           APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
           WRANGLER_CONFIG: ${{ steps.resources.outputs.wrangler_config }}
@@ -486,6 +492,7 @@ jobs:
       - name: 🗑️ Delete preview Workers
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
         run: |
           set -euo pipefail
@@ -532,6 +539,7 @@ jobs:
         if: always()
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           APP_WORKER_NAME: ${{ steps.names.outputs.worker_name }}
         run: |
           set -euo pipefail

--- a/client/app-root.tsx
+++ b/client/app-root.tsx
@@ -1,0 +1,26 @@
+import { clientEntry, type EntryComponent, type Handle } from 'remix/ui'
+import { App } from './app.tsx'
+import { RouterLocationProvider } from './router-location.tsx'
+import { type SessionInfo } from './session.ts'
+
+export const APP_ROOT_ENTRY_ID = '/client-entry.js#AppRoot'
+
+export type AppRootProps = {
+	url: string
+	session: SessionInfo | null
+	notFound?: boolean
+}
+
+export const AppRoot: EntryComponent<AppRootProps> = clientEntry(
+	APP_ROOT_ENTRY_ID,
+	function AppRoot(handle: Handle<AppRootProps>) {
+		return () => (
+			<RouterLocationProvider url={handle.props.url}>
+				<App
+					embeddedSession={handle.props.session}
+					notFound={handle.props.notFound === true}
+				/>
+			</RouterLocationProvider>
+		)
+	},
+)

--- a/client/app-root.tsx
+++ b/client/app-root.tsx
@@ -1,13 +1,16 @@
 import { clientEntry, type EntryComponent, type Handle } from 'remix/ui'
 import { App } from './app.tsx'
+import { AppLoaderDataProvider } from './route-loader-data.tsx'
 import { RouterLocationProvider } from './router-location.tsx'
 import { type SessionInfo } from './session.ts'
+import { type AppLoaderDataEnvelope } from '#shared/route-loader-data.ts'
 
 export const APP_ROOT_ENTRY_ID = '/client-entry.js#AppRoot'
 
 export type AppRootProps = {
 	url: string
 	session: SessionInfo | null
+	loaderData?: AppLoaderDataEnvelope | null
 	notFound?: boolean
 }
 
@@ -15,12 +18,14 @@ export const AppRoot: EntryComponent<AppRootProps> = clientEntry(
 	APP_ROOT_ENTRY_ID,
 	function AppRoot(handle: Handle<AppRootProps>) {
 		return () => (
-			<RouterLocationProvider url={handle.props.url}>
-				<App
-					embeddedSession={handle.props.session}
-					notFound={handle.props.notFound === true}
-				/>
-			</RouterLocationProvider>
+			<AppLoaderDataProvider loaderData={handle.props.loaderData ?? null}>
+				<RouterLocationProvider url={handle.props.url}>
+					<App
+						embeddedSession={handle.props.session}
+						notFound={handle.props.notFound === true}
+					/>
+				</RouterLocationProvider>
+			</AppLoaderDataProvider>
 		)
 	},
 )

--- a/client/app-session.tsx
+++ b/client/app-session.tsx
@@ -1,0 +1,36 @@
+import { type Handle, type RemixNode } from 'remix/ui'
+import { type SessionInfo, type SessionStatus } from './session.ts'
+
+export type AppSessionValue = {
+	session: SessionInfo | null
+	status: SessionStatus
+}
+
+export function AppSessionProvider(
+	handle: Handle<
+		{
+			session: SessionInfo | null
+			status: SessionStatus
+			children?: RemixNode
+		},
+		AppSessionValue
+	>,
+) {
+	handle.context.set({
+		session: handle.props.session,
+		status: handle.props.status,
+	})
+
+	return () => handle.props.children
+}
+
+export function readAppSession(
+	handle: Pick<Handle, 'context'>,
+): AppSessionValue {
+	return (
+		handle.context.get(AppSessionProvider) ?? {
+			session: null,
+			status: 'idle',
+		}
+	)
+}

--- a/client/app.tsx
+++ b/client/app.tsx
@@ -1,6 +1,12 @@
 import { css, on, type Handle } from 'remix/ui'
 import { clientRoutes, getClientDocumentTitle } from './routes/index.tsx'
 import { listenToRouterNavigation, Router } from './client-router.tsx'
+import { AppSessionProvider } from './app-session.tsx'
+import {
+	readRouterPathname,
+	readRouterSearch,
+	readRouterUrl,
+} from './router-location.tsx'
 import {
 	fetchSessionInfo,
 	type SessionInfo,
@@ -9,9 +15,15 @@ import {
 import { buildAuthLink } from './auth-links.ts'
 import { colors, spacing, typography, mq } from './styles/tokens.ts'
 
-export function App(handle: Handle) {
-	let session: SessionInfo | null = null
-	let sessionStatus: SessionStatus = 'idle'
+type AppProps = {
+	embeddedSession?: SessionInfo | null
+	notFound?: boolean
+}
+
+export function App(handle: Handle<AppProps>) {
+	let session: SessionInfo | null = handle.props.embeddedSession ?? null
+	let sessionStatus: SessionStatus =
+		handle.props.embeddedSession !== undefined ? 'ready' : 'idle'
 	let sessionRefreshInFlight = false
 	let sessionRefreshQueued = false
 
@@ -44,22 +56,25 @@ export function App(handle: Handle) {
 	}
 
 	function syncDocumentTitle() {
-		if (typeof window === 'undefined') return
-		document.title = getClientDocumentTitle(new URL(window.location.href))
+		if (typeof document === 'undefined') return
+		document.title = getClientDocumentTitle(
+			new URL(readRouterUrl(handle), 'https://kids-ledger.local'),
+		)
 	}
 
-	let currentPath =
-		typeof window !== 'undefined' ? window.location.pathname : '/'
+	let currentPath = readRouterPathname(handle)
 
-	handle.queueTask(() => {
-		queueSessionRefresh()
-		syncDocumentTitle()
-	})
-	listenToRouterNavigation(handle, () => {
-		currentPath = window.location.pathname
-		queueSessionRefresh()
-		syncDocumentTitle()
-	})
+	if (typeof document !== 'undefined') {
+		handle.queueTask(() => {
+			queueSessionRefresh()
+			syncDocumentTitle()
+		})
+		listenToRouterNavigation(handle, () => {
+			currentPath = readRouterPathname(handle)
+			queueSessionRefresh()
+			syncDocumentTitle()
+		})
+	}
 
 	function getNavLinkCss(href: string) {
 		const isActive = currentPath === href
@@ -252,14 +267,14 @@ export function App(handle: Handle) {
 	})
 
 	return () => {
+		currentPath = readRouterPathname(handle)
 		const sessionEmail = session?.email ?? ''
 		const isSessionReady = sessionStatus === 'ready'
 		const isLoggedIn = isSessionReady && Boolean(sessionEmail)
 		const showAuthLinks = isSessionReady && !isLoggedIn
 		const oauthRedirectTo =
-			typeof window !== 'undefined' &&
-			window.location.pathname === '/oauth/authorize'
-				? `${window.location.pathname}${window.location.search}`
+			currentPath === '/oauth/authorize'
+				? `${currentPath}${readRouterSearch(handle)}`
 				: null
 		const loginHref = buildAuthLink('/login', oauthRedirectTo)
 		const signupHref = buildAuthLink('/signup', oauthRedirectTo)
@@ -322,26 +337,29 @@ export function App(handle: Handle) {
 					) : null}
 				</nav>
 				<div mix={css(routeContentShellCss)}>
-					<Router
-						routes={clientRoutes}
-						fallback={
-							<section>
-								<h2
-									mix={css({
-										fontSize: typography.fontSize.lg,
-										fontWeight: typography.fontWeight.semibold,
-										marginBottom: spacing.sm,
-										color: colors.text,
-									})}
-								>
-									Not Found
-								</h2>
-								<p mix={css({ color: colors.textMuted })}>
-									That route does not exist.
-								</p>
-							</section>
-						}
-					/>
+					<AppSessionProvider session={session} status={sessionStatus}>
+						<Router
+							routes={clientRoutes}
+							notFound={handle.props.notFound}
+							fallback={
+								<section>
+									<h2
+										mix={css({
+											fontSize: typography.fontSize.lg,
+											fontWeight: typography.fontWeight.semibold,
+											marginBottom: spacing.sm,
+											color: colors.text,
+										})}
+									>
+										Not Found
+									</h2>
+									<p mix={css({ color: colors.textMuted })}>
+										That route does not exist.
+									</p>
+								</section>
+							}
+						/>
+					</AppSessionProvider>
 				</div>
 				<footer
 					mix={css({

--- a/client/client-router.tsx
+++ b/client/client-router.tsx
@@ -5,9 +5,16 @@ import {
 	readRouterUrl,
 	readSsrRouterUrl,
 } from './router-location.tsx'
+import {
+	clearPreloadedNavigationData,
+	routeDataEvents,
+	setPreloadedNavigationData,
+	type ClientRouteLoader,
+} from './route-loader-data.tsx'
 
 type RouteDefinition = {
 	Component: (...args: Array<any>) => any
+	loader?: ClientRouteLoader
 }
 
 type RouterProps = {
@@ -32,6 +39,8 @@ const routeMatchers = new WeakMap<
 	ReturnType<typeof createRouteMatcher>
 >()
 let routerInitialized = false
+let activeRoutes: Record<string, RouteDefinition> | null = null
+let activeLoaderController: AbortController | null = null
 
 function notify() {
 	routerEvents.dispatchEvent(new Event('navigate'))
@@ -87,7 +96,7 @@ function handleDocumentClick(event: MouseEvent) {
 
 	event.preventDefault()
 	const destination = new URL(anchor.href, window.location.href)
-	navigate(`${destination.pathname}${destination.search}${destination.hash}`)
+	void navigateToUrl(destination)
 }
 
 function getFormSubmitter(event: SubmitEvent) {
@@ -188,15 +197,16 @@ function getPathWithSearchAndHashFromUrl(url: URL) {
 	return `${url.pathname}${url.search}${url.hash}`
 }
 
-function navigateWithRefreshForSamePath(destination: URL) {
+async function navigateWithRefreshForSamePath(destination: URL) {
 	if (
 		getPathWithSearchAndHashFromUrl(destination) ===
 		getCurrentPathWithSearchAndHash()
 	) {
+		await preloadRouteData(destination)
 		notify()
 		return
 	}
-	navigate(destination.toString())
+	await navigateToUrl(destination)
 }
 
 async function submitFormThroughRouter(details: FormSubmitDetails) {
@@ -227,13 +237,15 @@ async function submitFormThroughRouter(details: FormSubmitDetails) {
 
 	const response = await fetch(details.action.toString(), init)
 	if (response.redirected) {
-		navigateWithRefreshForSamePath(new URL(response.url, window.location.href))
+		await navigateWithRefreshForSamePath(
+			new URL(response.url, window.location.href),
+		)
 		return
 	}
 
 	const location = response.headers.get('Location')
 	if (location) {
-		navigateWithRefreshForSamePath(new URL(location, details.action))
+		await navigateWithRefreshForSamePath(new URL(location, details.action))
 		return
 	}
 
@@ -259,13 +271,67 @@ function handleDocumentSubmit(event: Event) {
 	})
 }
 
-function ensureRouter() {
+async function preloadRouteData(destination: URL) {
+	if (!activeRoutes) return
+	activeLoaderController?.abort()
+	const routeElement = matchRoute(destination.pathname, activeRoutes)
+	if (!routeElement?.loader) {
+		clearPreloadedNavigationData()
+		return
+	}
+	const controller = new AbortController()
+	activeLoaderController = controller
+	try {
+		const data = await routeElement.loader({
+			url: destination,
+			signal: controller.signal,
+		})
+		if (controller.signal.aborted) return
+		if (data && Object.keys(data).length > 0) {
+			setPreloadedNavigationData(
+				getPathWithSearchAndHashFromUrl(destination),
+				data,
+			)
+		} else {
+			clearPreloadedNavigationData()
+		}
+	} catch (error) {
+		if (!controller.signal.aborted) {
+			console.error('Route loader failed', error)
+			clearPreloadedNavigationData()
+		}
+	} finally {
+		if (activeLoaderController === controller) {
+			activeLoaderController = null
+		}
+	}
+}
+
+async function revalidateCurrentRouteData() {
+	if (typeof window === 'undefined') return
+	await preloadRouteData(new URL(window.location.href))
+	notify()
+}
+
+function handlePopstate() {
+	void revalidateCurrentRouteData()
+}
+
+function handleRouteDataRevalidation() {
+	void revalidateCurrentRouteData()
+}
+
+function ensureRouter(routes?: Record<string, RouteDefinition>) {
 	if (typeof document === 'undefined') return
+	if (routes) {
+		activeRoutes = routes
+	}
 	if (routerInitialized) return
 	routerInitialized = true
-	window.addEventListener('popstate', notify)
+	window.addEventListener('popstate', handlePopstate)
 	document.addEventListener('click', handleDocumentClick)
 	document.addEventListener('submit', handleDocumentSubmit)
+	routeDataEvents.addEventListener('revalidate', handleRouteDataRevalidation)
 }
 
 export function listenToRouterNavigation(
@@ -306,15 +372,21 @@ export function navigate(to: string) {
 		return
 	}
 
+	void navigateToUrl(destination)
+}
+
+async function navigateToUrl(destination: URL) {
 	const nextPath = `${destination.pathname}${destination.search}${destination.hash}`
 	if (nextPath === getCurrentPathWithSearchAndHash()) return
 
+	await preloadRouteData(destination)
 	window.history.pushState({}, '', nextPath)
 	notify()
 }
 
 export function Router(handle: Handle<RouterProps>) {
 	if (typeof document !== 'undefined') {
+		ensureRouter(handle.props.routes)
 		listenToRouterNavigation(handle, () => {
 			void handle.update()
 		})

--- a/client/client-router.tsx
+++ b/client/client-router.tsx
@@ -1,4 +1,10 @@
-import { type Handle } from 'remix/ui'
+import { addEventListeners, type Handle } from 'remix/ui'
+import { createMultiMatcher } from 'remix/route-pattern/match'
+import {
+	readRouterPathname,
+	readRouterUrl,
+	readSsrRouterUrl,
+} from './router-location.tsx'
 
 type RouteDefinition = {
 	Component: (...args: Array<any>) => any
@@ -7,6 +13,7 @@ type RouteDefinition = {
 type RouterProps = {
 	routes: Record<string, RouteDefinition>
 	fallback?: JSX.Element
+	notFound?: boolean
 }
 
 type FormMethod = 'get' | 'post'
@@ -19,26 +26,41 @@ type FormSubmitDetails = {
 }
 
 export const routerEvents = new EventTarget()
+const clientRouteOrigin = 'https://kids-ledger.local'
+const routeMatchers = new WeakMap<
+	Record<string, RouteDefinition>,
+	ReturnType<typeof createRouteMatcher>
+>()
 let routerInitialized = false
 
 function notify() {
 	routerEvents.dispatchEvent(new Event('navigate'))
 }
 
-function matchPathname(pattern: string, pathname: string) {
-	return new URLPattern({ pathname: pattern }).test({ pathname })
+function createRouteMatcher(routes: Record<string, RouteDefinition>) {
+	const matcher = createMultiMatcher<RouteDefinition>()
+	for (const [pattern, routeElement] of Object.entries(routes)) {
+		matcher.add(pattern, routeElement)
+	}
+	return matcher
 }
 
-function matchRoute(
+function getRouteMatcher(routes: Record<string, RouteDefinition>) {
+	const existing = routeMatchers.get(routes)
+	if (existing) return existing
+	const matcher = createRouteMatcher(routes)
+	routeMatchers.set(routes, matcher)
+	return matcher
+}
+
+export function matchRoute(
 	path: string,
 	routes: Record<string, RouteDefinition>,
 ): RouteDefinition | null {
-	for (const [pattern, routeElement] of Object.entries(routes)) {
-		if (!matchPathname(pattern, path)) continue
-		return routeElement
-	}
-
-	return null
+	return (
+		getRouteMatcher(routes).match(new URL(path, clientRouteOrigin))?.data ??
+		null
+	)
 }
 
 function shouldHandleClick(event: MouseEvent, anchor: HTMLAnchorElement) {
@@ -238,6 +260,7 @@ function handleDocumentSubmit(event: Event) {
 }
 
 function ensureRouter() {
+	if (typeof document === 'undefined') return
 	if (routerInitialized) return
 	routerInitialized = true
 	window.addEventListener('popstate', notify)
@@ -246,18 +269,26 @@ function ensureRouter() {
 }
 
 export function listenToRouterNavigation(
-	handle: Handle<any>,
+	handle: Pick<Handle, 'signal'>,
 	listener: () => void,
 ) {
+	if (typeof document === 'undefined') return
 	ensureRouter()
-	const onNavigate = () => listener()
-	routerEvents.addEventListener('navigate', onNavigate)
-	handle.signal.addEventListener('abort', () => {
-		routerEvents.removeEventListener('navigate', onNavigate)
+	addEventListeners(routerEvents, handle.signal, {
+		navigate() {
+			listener()
+		},
 	})
 }
 
-export function getPathname() {
+export function getPathname(handle?: Pick<Handle, 'context'>) {
+	if (handle) {
+		try {
+			return readRouterPathname(handle as Handle)
+		} catch {
+			// Router location context is unavailable outside the app tree.
+		}
+	}
 	if (typeof window === 'undefined') return '/'
 	return window.location.pathname
 }
@@ -283,13 +314,19 @@ export function navigate(to: string) {
 }
 
 export function Router(handle: Handle<RouterProps>) {
-	listenToRouterNavigation(handle, () => {
-		void handle.update()
-	})
+	if (typeof document !== 'undefined') {
+		listenToRouterNavigation(handle, () => {
+			void handle.update()
+		})
+	}
 
 	return () => {
 		const { fallback, routes } = handle.props
-		const path = getPathname()
+		if (handle.props.notFound && isOnSsrUrl(handle)) {
+			return fallback ?? null
+		}
+
+		const path = readRouterPathname(handle)
 		const routeElement = matchRoute(path, routes)
 		if (routeElement) {
 			const RouteComponent = routeElement.Component
@@ -297,4 +334,16 @@ export function Router(handle: Handle<RouterProps>) {
 		}
 		return fallback ?? null
 	}
+}
+
+function normalizeHref(href: string) {
+	const url = new URL(href, clientRouteOrigin)
+	return `${url.pathname}${url.search}${url.hash}`
+}
+
+function isOnSsrUrl(handle: Pick<Handle, 'context'>) {
+	return (
+		normalizeHref(readRouterUrl(handle)) ===
+		normalizeHref(readSsrRouterUrl(handle))
+	)
 }

--- a/client/client-router.tsx
+++ b/client/client-router.tsx
@@ -314,7 +314,10 @@ async function revalidateCurrentRouteData() {
 }
 
 function handlePopstate() {
-	void revalidateCurrentRouteData()
+	notify()
+	void preloadRouteData(new URL(window.location.href)).then(() => {
+		notify()
+	})
 }
 
 function handleRouteDataRevalidation() {

--- a/client/entry.tsx
+++ b/client/entry.tsx
@@ -1,9 +1,26 @@
-import { createRoot } from 'remix/ui'
-import { App } from './app.tsx'
+import { run } from 'remix/ui'
+import { AppRoot, APP_ROOT_ENTRY_ID } from './app-root.tsx'
 
-const rootElement = document.getElementById('root') ?? document.body
-if (rootElement.childNodes.length > 0) {
-	// Remix alpha.3 auto-hydrates non-empty containers. We render from scratch.
-	rootElement.replaceChildren()
+const clientRegistry: Record<string, typeof AppRoot> = {
+	AppRoot,
 }
-createRoot(rootElement).render(<App />)
+
+const app = run({
+	loadModule(moduleUrl, exportName) {
+		const expectedHref = APP_ROOT_ENTRY_ID.split('#')[0]
+		if (moduleUrl !== expectedHref) {
+			throw new Error(`Unknown client module URL: ${moduleUrl}`)
+		}
+		const component = clientRegistry[exportName]
+		if (!component) {
+			throw new Error(`Unknown client export: ${exportName}`)
+		}
+		return component
+	},
+})
+
+app.addEventListener('error', (event) => {
+	console.error('Client hydration error:', event.error)
+})
+
+void app.ready()

--- a/client/http.ts
+++ b/client/http.ts
@@ -1,7 +1,10 @@
 export async function parseJsonOrNull<T = unknown>(
 	response: Response,
 ): Promise<T | null> {
-	return response.json().catch(() => null)
+	return response.json().then(
+		(value) => value as T,
+		() => null,
+	)
 }
 
 export function getErrorMessage(payload: unknown, fallback: string) {

--- a/client/ledger-api.ts
+++ b/client/ledger-api.ts
@@ -1,4 +1,5 @@
 import { getErrorMessage, parseJsonOrNull } from '#client/http.ts'
+import { requestRouteDataRevalidation } from '#client/route-loader-data.tsx'
 
 export type KidAccount = {
 	id: number
@@ -59,6 +60,28 @@ export type LedgerTransactionsPage = {
 	endPageCursor: string | null
 }
 
+export type LedgerSettings = {
+	kids: Array<KidSummary>
+	archived: {
+		kids: Array<{
+			id: number
+			name: string
+			emoji: string
+			sortOrder: number
+		}>
+		accounts: Array<{
+			id: number
+			name: string
+			apyBasisPoints: number
+			colorToken: string
+			sortOrder: number
+			kidId: number
+			kidName: string
+		}>
+	}
+	quickAmounts: Array<number>
+}
+
 async function parseApiResponse<T>(response: Response): Promise<T> {
 	const payload = await parseJsonOrNull(response)
 	if (!response.ok || payload === null) {
@@ -76,7 +99,9 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify(body),
 	})
-	return parseApiResponse<T>(response)
+	const payload = await parseApiResponse<T>(response)
+	requestRouteDataRevalidation()
+	return payload
 }
 
 async function getJson<T>(path: string): Promise<T> {
@@ -97,27 +122,7 @@ export async function fetchDashboard() {
 export async function fetchSettings() {
 	return getJson<{
 		ok: true
-		settings: {
-			kids: Array<KidSummary>
-			archived: {
-				kids: Array<{
-					id: number
-					name: string
-					emoji: string
-					sortOrder: number
-				}>
-				accounts: Array<{
-					id: number
-					name: string
-					apyBasisPoints: number
-					colorToken: string
-					sortOrder: number
-					kidId: number
-					kidName: string
-				}>
-			}
-			quickAmounts: Array<number>
-		}
+		settings: LedgerSettings
 	}>('/ledger/settings')
 }
 

--- a/client/route-loader-data.test.ts
+++ b/client/route-loader-data.test.ts
@@ -1,0 +1,67 @@
+/// <reference types="bun" />
+import { expect, test } from 'bun:test'
+import { type Handle } from 'remix/ui'
+import {
+	AppLoaderDataProvider,
+	clearPreloadedNavigationData,
+	setPreloadedNavigationData,
+	tryConsumeRouteLoaderData,
+} from './route-loader-data.tsx'
+
+type QueueTask = Parameters<Handle['queueTask']>[0]
+
+function createStubHandle() {
+	const queuedTasks: Array<QueueTask> = []
+	let updateCount = 0
+	const handle = {
+		context: {
+			get(provider: unknown) {
+				if (provider === AppLoaderDataProvider) {
+					return { loaderData: null, consumedKeys: new Set() }
+				}
+				return undefined
+			},
+		},
+		queueTask(task: QueueTask) {
+			queuedTasks.push(task)
+		},
+		update() {
+			updateCount++
+			return Promise.resolve(new AbortController().signal)
+		},
+	} as unknown as Handle
+	return {
+		handle,
+		queuedTasks,
+		getUpdateCount: () => updateCount,
+	}
+}
+
+test('consuming preloaded route data schedules one corrective render', async () => {
+	clearPreloadedNavigationData()
+	setPreloadedNavigationData('/account', {
+		accountSession: { email: 'parent@example.com' },
+	})
+	const { handle, queuedTasks, getUpdateCount } = createStubHandle()
+
+	const session = tryConsumeRouteLoaderData(
+		handle,
+		'accountSession',
+		'/account',
+	)
+	expect(session?.email).toBe('parent@example.com')
+	expect(queuedTasks).toHaveLength(1)
+	await queuedTasks.shift()!(new AbortController().signal)
+	expect(getUpdateCount()).toBe(1)
+
+	const reconsumed = tryConsumeRouteLoaderData(
+		handle,
+		'accountSession',
+		'/account',
+	)
+	expect(reconsumed).toBeUndefined()
+	expect(queuedTasks).toHaveLength(0)
+	expect(getUpdateCount()).toBe(1)
+
+	clearPreloadedNavigationData()
+})

--- a/client/route-loader-data.tsx
+++ b/client/route-loader-data.tsx
@@ -1,0 +1,123 @@
+import { type Handle, type RemixNode } from 'remix/ui'
+import {
+	type AppLoaderData,
+	type AppLoaderDataEnvelope,
+	type AppLoaderDataPayload,
+} from '#shared/route-loader-data.ts'
+
+export type ClientRouteLoader = (input: {
+	url: URL
+	signal: AbortSignal
+}) => Promise<AppLoaderDataPayload | null | undefined>
+
+type AppLoaderDataContextValue = {
+	loaderData: AppLoaderDataEnvelope | null
+	consumedKeys: Set<string>
+}
+
+type PreloadedNavigationData = AppLoaderDataEnvelope & {
+	consumedKeys: Set<string>
+}
+
+export const routeDataEvents = new EventTarget()
+
+let preloadedNavigationData: PreloadedNavigationData | null = null
+
+function normalizeRouterHref(href: string) {
+	const url = new URL(href, 'https://kids-ledger.local')
+	return `${url.pathname}${url.search}`
+}
+
+function getConsumedKey(key: keyof AppLoaderData, href: string) {
+	return `${normalizeRouterHref(href)}:${String(key)}`
+}
+
+function hrefMatches(left: string, right: string) {
+	return normalizeRouterHref(left) === normalizeRouterHref(right)
+}
+
+export function AppLoaderDataProvider(
+	handle: Handle<
+		{ loaderData?: AppLoaderDataEnvelope | null; children?: RemixNode },
+		AppLoaderDataContextValue
+	>,
+) {
+	handle.context.set({
+		loaderData: handle.props.loaderData ?? null,
+		consumedKeys: new Set(),
+	})
+
+	return () => handle.props.children
+}
+
+export function setPreloadedNavigationData(
+	href: string,
+	data: AppLoaderDataPayload,
+) {
+	preloadedNavigationData = {
+		href,
+		data,
+		consumedKeys: new Set(),
+	}
+}
+
+export function clearPreloadedNavigationData() {
+	preloadedNavigationData = null
+}
+
+function tryConsumeEmbeddedLoaderData<K extends keyof AppLoaderData>(
+	handle: Pick<Handle, 'context'>,
+	key: K,
+	currentHref: string,
+): AppLoaderData[K] | undefined {
+	const context = handle.context.get(AppLoaderDataProvider)
+	const loaderData = context?.loaderData
+	if (!context || !loaderData || !hrefMatches(loaderData.href, currentHref)) {
+		return undefined
+	}
+	const consumedKey = getConsumedKey(key, currentHref)
+	if (context.consumedKeys.has(consumedKey)) return undefined
+	if (!(key in loaderData.data)) return undefined
+	context.consumedKeys.add(consumedKey)
+	return loaderData.data[key] as AppLoaderData[K]
+}
+
+function tryConsumePreloadedLoaderData<K extends keyof AppLoaderData>(
+	key: K,
+	currentHref: string,
+): AppLoaderData[K] | undefined {
+	const loaderData = preloadedNavigationData
+	if (!loaderData || !hrefMatches(loaderData.href, currentHref))
+		return undefined
+	const consumedKey = getConsumedKey(key, currentHref)
+	if (loaderData.consumedKeys.has(consumedKey)) return undefined
+	if (!(key in loaderData.data)) return undefined
+	loaderData.consumedKeys.add(consumedKey)
+	return loaderData.data[key] as AppLoaderData[K]
+}
+
+function scheduleCorrectiveRender(handle: Handle) {
+	handle.queueTask(() => {
+		void handle.update()
+	})
+}
+
+export function tryConsumeRouteLoaderData<K extends keyof AppLoaderData>(
+	handle: Handle,
+	key: K,
+	currentHref: string,
+): AppLoaderData[K] | undefined {
+	const embedded = tryConsumeEmbeddedLoaderData(handle, key, currentHref)
+	const data =
+		embedded !== undefined
+			? embedded
+			: tryConsumePreloadedLoaderData(key, currentHref)
+	if (data !== undefined) {
+		scheduleCorrectiveRender(handle)
+	}
+	return data
+}
+
+export function requestRouteDataRevalidation() {
+	routeDataEvents.dispatchEvent(new Event('revalidate'))
+}

--- a/client/router-location.tsx
+++ b/client/router-location.tsx
@@ -1,0 +1,57 @@
+import { addEventListeners, type Handle, type RemixNode } from 'remix/ui'
+import { routerEvents } from './client-router.tsx'
+
+export type RouterLocationValue = {
+	url: string
+	ssrUrl: string
+}
+
+function getClientUrl() {
+	if (typeof window === 'undefined') return '/'
+	return `${window.location.pathname}${window.location.search}${window.location.hash}`
+}
+
+export function RouterLocationProvider(
+	handle: Handle<{ url: string; children?: RemixNode }, RouterLocationValue>,
+) {
+	const ssrUrl = handle.props.url
+	let currentUrl = ssrUrl
+
+	if (typeof window !== 'undefined') {
+		handle.queueTask(() => {
+			currentUrl = getClientUrl()
+			handle.context.set({ url: currentUrl, ssrUrl })
+			handle.update()
+		})
+
+		addEventListeners(routerEvents, handle.signal, {
+			navigate() {
+				const nextUrl = getClientUrl()
+				if (nextUrl === currentUrl) return
+				currentUrl = nextUrl
+				handle.context.set({ url: currentUrl, ssrUrl })
+				handle.update()
+			},
+		})
+	}
+
+	handle.context.set({ url: currentUrl, ssrUrl })
+
+	return () => handle.props.children
+}
+
+export function readRouterUrl(handle: Pick<Handle, 'context'>) {
+	return handle.context.get(RouterLocationProvider).url
+}
+
+export function readSsrRouterUrl(handle: Pick<Handle, 'context'>) {
+	return handle.context.get(RouterLocationProvider).ssrUrl
+}
+
+export function readRouterPathname(handle: Pick<Handle, 'context'>) {
+	return new URL(readRouterUrl(handle), 'https://kids-ledger.local').pathname
+}
+
+export function readRouterSearch(handle: Pick<Handle, 'context'>) {
+	return new URL(readRouterUrl(handle), 'https://kids-ledger.local').search
+}

--- a/client/routes/account.tsx
+++ b/client/routes/account.tsx
@@ -1,33 +1,69 @@
 import { css, type Handle } from 'remix/ui'
-import { requireSessionOrRedirect } from '#client/session.ts'
+import { fetchSessionInfo, requireSessionOrRedirect } from '#client/session.ts'
+import {
+	tryConsumeRouteLoaderData,
+	type ClientRouteLoader,
+} from '#client/route-loader-data.tsx'
+import { readRouterUrl } from '#client/router-location.tsx'
 import { colors, spacing, typography } from '#client/styles/tokens.ts'
 import { buttonCss } from '#client/styles/form-controls.ts'
 
 type AccountStatus = 'idle' | 'loading' | 'ready' | 'error'
 
+export const loader: ClientRouteLoader = async ({ signal }) => {
+	return { accountSession: await fetchSessionInfo(signal) }
+}
+
 export function AccountRoute(handle: Handle) {
 	let status: AccountStatus = 'loading'
 	let email = ''
 	let message: string | null = null
+	let accountRefreshInFlight = false
+
+	function applySession(session: Awaited<ReturnType<typeof fetchSessionInfo>>) {
+		if (!session) return false
+		email = session.email
+		status = 'ready'
+		message = null
+		return true
+	}
+
+	function applyRouteLoaderData(currentHref: string) {
+		const session = tryConsumeRouteLoaderData(
+			handle,
+			'accountSession',
+			currentHref,
+		)
+		if (session === undefined) return false
+		if (applySession(session)) return true
+		if (typeof window !== 'undefined') {
+			window.location.assign('/login?redirectTo=/account')
+		}
+		return true
+	}
 
 	async function loadAccount(signal: AbortSignal) {
+		if (accountRefreshInFlight) return
+		accountRefreshInFlight = true
 		try {
 			const session = await requireSessionOrRedirect(signal)
 			if (signal.aborted || !session) return
-			email = session.email
-			status = 'ready'
-			message = null
+			applySession(session)
 			handle.update()
 		} catch {
 			if (signal.aborted) return
 			status = 'error'
 			message = 'Unable to load your account.'
 			handle.update()
+		} finally {
+			accountRefreshInFlight = false
 		}
 	}
 
 	return () => {
-		if (status === 'loading') {
+		const currentHref = readRouterUrl(handle)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		if (status === 'loading' && !appliedRouteData && !accountRefreshInFlight) {
 			handle.queueTask(loadAccount)
 		}
 

--- a/client/routes/history.tsx
+++ b/client/routes/history.tsx
@@ -5,8 +5,14 @@ import {
 	type LedgerTransaction,
 } from '#client/ledger-api.ts'
 import { listenToRouterNavigation, navigate } from '#client/client-router.tsx'
+import {
+	tryConsumeRouteLoaderData,
+	type ClientRouteLoader,
+} from '#client/route-loader-data.tsx'
+import { readRouterSearch, readRouterUrl } from '#client/router-location.tsx'
 import { formatCents } from '#client/money.ts'
 import { createSpinDelay } from '#client/spin-delay.ts'
+import { type HistoryLoaderData } from '#shared/route-loader-data.ts'
 import { getAccountGradientBackground } from '#client/styles/account-colors.ts'
 import { colors, mq, radius, shadows, spacing } from '#client/styles/tokens.ts'
 import { inputCss, buttonCss } from '#client/styles/form-controls.ts'
@@ -31,9 +37,12 @@ type HistoryState = {
 
 const defaultHistoryPageSize = 50
 
-function getInitialQuery() {
-	if (typeof window === 'undefined') return new URLSearchParams()
-	return new URLSearchParams(window.location.search)
+function getQueryFromSearch(search: string) {
+	const query = new URLSearchParams(search)
+	if (!query.get('limit')) {
+		query.set('limit', String(defaultHistoryPageSize))
+	}
+	return query
 }
 
 function getPage(query: URLSearchParams) {
@@ -77,6 +86,15 @@ const disabledPaginationControlCss = {
 	transform: 'none',
 }
 
+export const loader: ClientRouteLoader = async ({ url }) => {
+	const query = getQueryFromSearch(url.search)
+	const [settings, transactions] = await Promise.all([
+		fetchSettings(),
+		fetchTransactions(query),
+	])
+	return { history: { settings, transactions } }
+}
+
 function getTransactionTextColors(colorToken: string) {
 	if (colorToken === 'sun') {
 		return {
@@ -93,10 +111,7 @@ function getTransactionTextColors(colorToken: string) {
 }
 
 export function HistoryRoute(handle: Handle) {
-	let query = getInitialQuery()
-	if (!query.get('limit')) {
-		query.set('limit', String(defaultHistoryPageSize))
-	}
+	let query = getQueryFromSearch(readRouterSearch(handle))
 	let state: HistoryState = {
 		status: 'loading',
 		errorMessage: '',
@@ -117,6 +132,7 @@ export function HistoryRoute(handle: Handle) {
 	const pendingRefreshDelay = createSpinDelay(() => {
 		handle.update()
 	})
+	let historyRefreshInFlight = false
 
 	function updateQuery(next: URLSearchParams) {
 		if (!next.get('limit')) {
@@ -140,6 +156,8 @@ export function HistoryRoute(handle: Handle) {
 	}
 
 	async function loadHistory() {
+		if (historyRefreshInFlight) return
+		historyRefreshInFlight = true
 		state = { ...state, status: 'loading', errorMessage: '' }
 		pendingRefreshDelay.setLoading(true)
 		handle.update()
@@ -185,23 +203,73 @@ export function HistoryRoute(handle: Handle) {
 			}
 		}
 		pendingRefreshDelay.setLoading(false)
+		historyRefreshInFlight = false
 		handle.update()
 	}
 
-	handle.queueTask(async () => {
-		await loadHistory()
-	})
-	listenToRouterNavigation(handle, () => {
-		const next = getInitialQuery()
-		if (!next.get('limit')) {
-			next.set('limit', String(defaultHistoryPageSize))
+	function applyHistoryData(data: HistoryLoaderData) {
+		const kidOptions = data.settings.settings.kids.map((kid) => ({
+			id: kid.id,
+			name: kid.name,
+		}))
+		const accountOptions = data.settings.settings.kids.flatMap((kid) =>
+			kid.accounts.map((account) => ({
+				id: account.id,
+				name: account.name,
+				kidName: kid.name,
+			})),
+		)
+		state = {
+			status: 'ready',
+			errorMessage: '',
+			transactions: data.transactions.transactions,
+			page: data.transactions.page,
+			pageSize: data.transactions.pageSize,
+			totalCount: data.transactions.totalCount,
+			totalPages: data.transactions.totalPages,
+			hasPreviousPage: data.transactions.hasPreviousPage,
+			hasNextPage: data.transactions.hasNextPage,
+			startCursor: data.transactions.startCursor,
+			endCursor: data.transactions.endCursor,
+			middleCursor: data.transactions.middleCursor,
+			endPageCursor: data.transactions.endPageCursor,
+			kidOptions,
+			accountOptions,
 		}
-		if (next.toString() === query.toString()) return
-		query = next
-		void loadHistory()
+		pendingRefreshDelay.setLoading(false)
+	}
+
+	function applyRouteLoaderData(currentHref: string) {
+		const data = tryConsumeRouteLoaderData(handle, 'history', currentHref)
+		if (!data) return false
+		applyHistoryData(data)
+		return true
+	}
+
+	listenToRouterNavigation(handle, () => {
+		void handle.update()
 	})
 
 	return () => {
+		const currentHref = readRouterUrl(handle)
+		const nextQuery = getQueryFromSearch(readRouterSearch(handle))
+		if (nextQuery.toString() !== query.toString()) {
+			query = nextQuery
+			state = {
+				...state,
+				status: state.transactions.length > 0 ? state.status : 'loading',
+				errorMessage: '',
+			}
+		}
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		if (
+			typeof window !== 'undefined' &&
+			!appliedRouteData &&
+			!historyRefreshInFlight &&
+			(state.status === 'loading' || pendingRefreshDelay.isShowing())
+		) {
+			handle.queueTask(loadHistory)
+		}
 		const showPendingRefresh =
 			state.transactions.length > 0 && pendingRefreshDelay.isShowing()
 		return (

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -253,16 +253,21 @@ export function HomeRoute(handle: Handle) {
 		handle.update()
 	}
 
-	handle.queueTask(async () => {
-		const nextAppSession = readAppSession(handle)
-		if (nextAppSession.status === 'ready' && nextAppSession.session === null) {
-			status = 'error'
-			needsLogin = true
-			handle.update()
-			return
-		}
-		await refreshDashboard()
-	})
+	if (typeof window !== 'undefined') {
+		handle.queueTask(async () => {
+			const nextAppSession = readAppSession(handle)
+			if (
+				nextAppSession.status === 'ready' &&
+				nextAppSession.session === null
+			) {
+				status = 'error'
+				needsLogin = true
+				handle.update()
+				return
+			}
+			await refreshDashboard()
+		})
+	}
 	handle.queueTask(() => {
 		return () => {
 			clearCloseModalTimeout()

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -1,5 +1,10 @@
 import { css, on, type Handle } from 'remix/ui'
 import { readAppSession } from '#client/app-session.tsx'
+import { readRouterUrl } from '#client/router-location.tsx'
+import {
+	tryConsumeRouteLoaderData,
+	type ClientRouteLoader,
+} from '#client/route-loader-data.tsx'
 import {
 	createTransaction,
 	createTransfer,
@@ -75,6 +80,10 @@ function getInterestPreviewText(account: KidAccount) {
 	)} on ${formatPayoutDate(getNextMonthlyInterestPayoutDate())}`
 }
 
+export const loader: ClientRouteLoader = async () => {
+	return { dashboard: await fetchDashboard() }
+}
+
 export function HomeRoute(handle: Handle) {
 	const appSession = readAppSession(handle)
 	const isLoggedOutSsr =
@@ -95,6 +104,29 @@ export function HomeRoute(handle: Handle) {
 	let transferModalOpener: HTMLButtonElement | null = null
 	let transferModalClosing = false
 	let closeTransferModalTimeoutId: number | null = null
+	let dashboardRefreshInFlight = false
+
+	function applyDashboard(
+		dashboard: Awaited<ReturnType<typeof fetchDashboard>>,
+	) {
+		kids = dashboard.kids
+		familyBalance = dashboard.familyBalanceCents
+		quickAmounts = dashboard.quickAmounts
+		status = 'ready'
+		errorMessage = ''
+		needsLogin = false
+	}
+
+	function applyRouteLoaderData(currentHref: string) {
+		const dashboard = tryConsumeRouteLoaderData(
+			handle,
+			'dashboard',
+			currentHref,
+		)
+		if (!dashboard) return false
+		applyDashboard(dashboard)
+		return true
+	}
 
 	function removeTransactionModalStyles() {
 		if (typeof document === 'undefined') return
@@ -234,40 +266,24 @@ export function HomeRoute(handle: Handle) {
 	}
 
 	async function refreshDashboard() {
+		if (dashboardRefreshInFlight) return
+		dashboardRefreshInFlight = true
 		status = 'loading'
 		needsLogin = false
 		handle.update()
 		try {
 			const dashboard = await fetchDashboard()
-			kids = dashboard.kids
-			familyBalance = dashboard.familyBalanceCents
-			quickAmounts = dashboard.quickAmounts
-			status = 'ready'
-			errorMessage = ''
+			applyDashboard(dashboard)
 		} catch (error) {
 			status = 'error'
 			errorMessage =
 				error instanceof Error ? error.message : 'Failed to load ledger data.'
 			needsLogin = isAuthError(errorMessage)
 		}
+		dashboardRefreshInFlight = false
 		handle.update()
 	}
 
-	if (typeof window !== 'undefined') {
-		handle.queueTask(async () => {
-			const nextAppSession = readAppSession(handle)
-			if (
-				nextAppSession.status === 'ready' &&
-				nextAppSession.session === null
-			) {
-				status = 'error'
-				needsLogin = true
-				handle.update()
-				return
-			}
-			await refreshDashboard()
-		})
-	}
 	handle.queueTask(() => {
 		return () => {
 			clearCloseModalTimeout()
@@ -391,637 +407,629 @@ export function HomeRoute(handle: Handle) {
 		}
 	}
 
-	return () => (
-		<section mix={css({ display: 'grid', gap: spacing.lg })}>
-			{status === 'ready' ? (
-				<header
-					mix={css({
-						display: 'grid',
-						gap: spacing.sm,
-						justifyItems: 'center',
-						textAlign: 'center',
-					})}
-				>
-					<h1 mix={css({ margin: 0, color: colors.text })}>Family Ledger</h1>
-					<p mix={css({ margin: 0, color: colors.textMuted })}>
-						Family Total:{' '}
-						<strong mix={css({ color: colors.text })}>
-							{formatCents(familyBalance)}
-						</strong>
-					</p>
-				</header>
-			) : null}
+	return () => {
+		const currentHref = readRouterUrl(handle)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		if (
+			typeof window !== 'undefined' &&
+			status === 'loading' &&
+			!appliedRouteData &&
+			!dashboardRefreshInFlight
+		) {
+			handle.queueTask(async () => {
+				const nextAppSession = readAppSession(handle)
+				if (
+					nextAppSession.status === 'ready' &&
+					nextAppSession.session === null
+				) {
+					status = 'error'
+					needsLogin = true
+					handle.update()
+					return
+				}
+				await refreshDashboard()
+			})
+		}
 
-			{status === 'loading' ? (
-				<p mix={css({ color: colors.textMuted })}>Loading your ledger...</p>
-			) : null}
-			{status === 'error' && needsLogin ? LoggedOutHome() : null}
-			{status === 'error' && !needsLogin ? (
-				<p mix={css({ color: colors.error })}>{errorMessage}</p>
-			) : null}
-			{status === 'ready' && kids.length === 0 ? (
-				<section
-					mix={css({
-						padding: spacing.lg,
-						border: `3px dashed ${colors.border}`,
-						borderRadius: radius.xl,
-						backgroundColor: colors.surface,
-						display: 'grid',
-						gap: spacing.sm,
-					})}
-				>
-					<h2 mix={css({ margin: 0, color: colors.text })}>No kids yet</h2>
-					<p mix={css({ margin: 0, color: colors.textMuted })}>
-						Open <a href="/settings">Settings</a> to add your first kid and
-						account.
-					</p>
-				</section>
-			) : null}
-
-			{kids.map((kid) => (
-				<article
-					key={kid.id}
-					mix={css({
-						display: 'grid',
-						gap: spacing.md,
-						padding: spacing.lg,
-						borderRadius: radius.xl,
-						border: `3px solid ${colors.border}`,
-						backgroundColor: colors.surface,
-						boxShadow: shadows.md,
-					})}
-				>
+		return (
+			<section mix={css({ display: 'grid', gap: spacing.lg })}>
+				{status === 'ready' ? (
 					<header
 						mix={css({
-							display: 'flex',
-							justifyContent: 'space-between',
-							alignItems: 'center',
-							gap: spacing.md,
+							display: 'grid',
+							gap: spacing.sm,
+							justifyItems: 'center',
+							textAlign: 'center',
 						})}
 					>
-						<div>
-							<h2 mix={css({ margin: 0, color: colors.text })}>
-								{kid.emoji} {kid.name}
-							</h2>
-							<p mix={css({ margin: 0, color: colors.textMuted })}>
-								Total: {formatCents(kid.totalBalanceCents)}
-							</p>
-						</div>
+						<h1 mix={css({ margin: 0, color: colors.text })}>Family Ledger</h1>
+						<p mix={css({ margin: 0, color: colors.textMuted })}>
+							Family Total:{' '}
+							<strong mix={css({ color: colors.text })}>
+								{formatCents(familyBalance)}
+							</strong>
+						</p>
 					</header>
-					<div mix={css({ display: 'grid', gap: spacing.sm })}>
-						{kid.accounts.length === 0 ? (
-							<p mix={css({ margin: 0, color: colors.textMuted })}>
-								No accounts yet. <a href="/settings">Add one in settings.</a>
-							</p>
+				) : null}
+
+				{status === 'loading' ? (
+					<p mix={css({ color: colors.textMuted })}>Loading your ledger...</p>
+				) : null}
+				{status === 'error' && needsLogin ? LoggedOutHome() : null}
+				{status === 'error' && !needsLogin ? (
+					<p mix={css({ color: colors.error })}>{errorMessage}</p>
+				) : null}
+				{status === 'ready' && kids.length === 0 ? (
+					<section
+						mix={css({
+							padding: spacing.lg,
+							border: `3px dashed ${colors.border}`,
+							borderRadius: radius.xl,
+							backgroundColor: colors.surface,
+							display: 'grid',
+							gap: spacing.sm,
+						})}
+					>
+						<h2 mix={css({ margin: 0, color: colors.text })}>No kids yet</h2>
+						<p mix={css({ margin: 0, color: colors.textMuted })}>
+							Open <a href="/settings">Settings</a> to add your first kid and
+							account.
+						</p>
+					</section>
+				) : null}
+
+				{kids.map((kid) => (
+					<article
+						key={kid.id}
+						mix={css({
+							display: 'grid',
+							gap: spacing.md,
+							padding: spacing.lg,
+							borderRadius: radius.xl,
+							border: `3px solid ${colors.border}`,
+							backgroundColor: colors.surface,
+							boxShadow: shadows.md,
+						})}
+					>
+						<header
+							mix={css({
+								display: 'flex',
+								justifyContent: 'space-between',
+								alignItems: 'center',
+								gap: spacing.md,
+							})}
+						>
+							<div>
+								<h2 mix={css({ margin: 0, color: colors.text })}>
+									{kid.emoji} {kid.name}
+								</h2>
+								<p mix={css({ margin: 0, color: colors.textMuted })}>
+									Total: {formatCents(kid.totalBalanceCents)}
+								</p>
+							</div>
+						</header>
+						<div mix={css({ display: 'grid', gap: spacing.sm })}>
+							{kid.accounts.length === 0 ? (
+								<p mix={css({ margin: 0, color: colors.textMuted })}>
+									No accounts yet. <a href="/settings">Add one in settings.</a>
+								</p>
+							) : null}
+							{kid.accounts.map((account) => {
+								const interestPreviewText = getInterestPreviewText(account)
+								return (
+									<article
+										key={account.id}
+										mix={css({
+											display: 'grid',
+											gridTemplateColumns: '1fr',
+											gap: spacing.sm,
+											alignItems: 'stretch',
+											padding: spacing.xs,
+											borderRadius: radius.lg,
+											background: getAccountGradientBackground(
+												account.colorToken,
+											),
+											color: '#ffffff',
+											boxShadow: `0 4px 0 0 rgba(0,0,0,0.2)`,
+											[mq.mobile]: {
+												gridTemplateColumns: '1fr',
+											},
+										})}
+									>
+										<button
+											type="button"
+											mix={[
+												css({
+													display: 'flex',
+													justifyContent: 'space-between',
+													alignItems: 'center',
+													gap: spacing.sm,
+													minWidth: 0,
+													padding: spacing.sm,
+													border: 'none',
+													borderRadius: radius.md,
+													background: 'transparent',
+													color: 'inherit',
+													cursor: 'pointer',
+													textAlign: 'left',
+													transition: `background-color ${transitions.fast}`,
+													'&:hover': {
+														backgroundColor: 'rgba(255,255,255,0.14)',
+													},
+												}),
+												on<HTMLElement, 'click'>('click', (event) => {
+													if (
+														!(event.currentTarget instanceof HTMLButtonElement)
+													)
+														return
+													openTransactionModal(
+														kid,
+														account,
+														event.currentTarget,
+													)
+												}),
+											]}
+										>
+											<span
+												mix={css({
+													display: 'grid',
+													gap: 2,
+													minWidth: 0,
+													fontWeight: typography.fontWeight.semibold,
+												})}
+											>
+												{account.name}
+												<span
+													mix={css({
+														fontSize: typography.fontSize.sm,
+														opacity: 0.9,
+													})}
+												>
+													Tap to add or remove money
+												</span>
+												{interestPreviewText ? (
+													<span
+														mix={css({
+															fontSize: typography.fontSize.sm,
+															fontWeight: typography.fontWeight.normal,
+															opacity: 0.9,
+														})}
+													>
+														{interestPreviewText}
+													</span>
+												) : null}
+											</span>
+											<strong
+												mix={css({
+													flexShrink: 0,
+													fontSize: typography.fontSize.lg,
+												})}
+											>
+												{formatCents(account.balanceCents)}
+											</strong>
+										</button>
+									</article>
+								)
+							})}
+						</div>
+					</article>
+				))}
+
+				{status === 'ready' ? (
+					<section
+						mix={css({
+							display: 'grid',
+							gap: spacing.sm,
+							padding: spacing.lg,
+							borderRadius: radius.xl,
+							border: `3px solid ${colors.border}`,
+							backgroundColor: colors.surface,
+							boxShadow: shadows.md,
+							textAlign: 'center',
+						})}
+					>
+						<h2 mix={css({ margin: 0, color: colors.text })}>
+							Move money around
+						</h2>
+						<p mix={css({ margin: 0, color: colors.textMuted })}>
+							Transfer between any two accounts. Same-kid accounts are suggested
+							first.
+						</p>
+						<button
+							type="button"
+							disabled={getTransferAccountOptions(kids).length < 2}
+							mix={[
+								css({
+									...buttonCss,
+									justifySelf: 'center',
+									minWidth: 'min(100%, 18rem)',
+									paddingInline: spacing.lg,
+								}),
+								on<HTMLElement, 'click'>('click', (event) => {
+									if (!(event.currentTarget instanceof HTMLButtonElement))
+										return
+									openTransferModal(event.currentTarget)
+								}),
+							]}
+						>
+							Transfer money
+						</button>
+					</section>
+				) : null}
+
+				{transactionState ? (
+					<div
+						mix={[
+							css({
+								position: 'fixed',
+								inset: 0,
+								backgroundColor: 'rgba(0, 0, 0, 0.45)',
+								display: 'grid',
+								placeItems: 'center',
+								padding: spacing.md,
+								zIndex: 1000,
+								pointerEvents: transactionModalClosing ? 'none' : 'auto',
+								animation: transactionModalClosing
+									? `modal-backdrop-out ${modalCloseAnimationDurationMs}ms ease-in forwards`
+									: 'modal-backdrop-in 180ms ease-out forwards',
+								[mq.mobile]: {
+									padding: 0,
+									placeItems: 'stretch',
+								},
+							}),
+							on<HTMLElement, 'click'>('click', (event) => {
+								if (event.target === event.currentTarget) {
+									closeTransactionModal()
+								}
+							}),
+						]}
+					>
+						{transactionState.kid.transactionModalCss.trim() ? (
+							<style data-kid-transaction-modal-css>
+								{buildTransactionModalCss(
+									transactionState.kid.transactionModalCss,
+								)}
+							</style>
 						) : null}
-						{kid.accounts.map((account) => {
-							const interestPreviewText = getInterestPreviewText(account)
-							return (
-								<article
-									key={account.id}
+						<section
+							role="dialog"
+							aria-modal="true"
+							aria-labelledby="transaction-modal-title"
+							aria-describedby="transaction-modal-description"
+							data-kid-transaction-modal
+							mix={[
+								css({
+									width: 'min(30rem, 100%)',
+									maxHeight: 'calc(100dvh - 2 * var(--spacing-md))',
+									overflow: 'auto',
+									display: 'grid',
+									gap: spacing.md,
+									padding: spacing.lg,
+									fontFamily: typography.fontFamily,
+									borderRadius: radius.xl,
+									border: `3px solid ${colors.border}`,
+									backgroundColor: colors.surface,
+									boxShadow: shadows.lg,
+									animation: transactionModalClosing
+										? `modal-close ${modalCloseAnimationDurationMs}ms ease-in forwards`
+										: 'modal-pop 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards',
+									[mq.mobile]: {
+										width: '100%',
+										maxHeight: '100dvh',
+										minHeight: '100dvh',
+										borderRadius: 0,
+										border: 'none',
+										gap: spacing.sm,
+										padding: spacing.md,
+									},
+								}),
+								on<HTMLElement, 'keydown'>(
+									'keydown',
+									handleTransactionModalKeydown,
+								),
+							]}
+						>
+							<header
+								mix={css({ display: 'flex', justifyContent: 'space-between' })}
+							>
+								<div>
+									<h3
+										id="transaction-modal-title"
+										mix={css({ margin: 0, color: colors.text })}
+									>
+										{transactionState.kid.emoji} {transactionState.kid.name}
+									</h3>
+									<p
+										id="transaction-modal-description"
+										mix={css({ margin: 0, color: colors.textMuted })}
+									>
+										{transactionState.account.name} ·{' '}
+										{formatCents(transactionState.account.balanceCents)}
+									</p>
+								</div>
+								<button
+									id="transaction-modal-close"
+									type="button"
+									mix={[
+										css({
+											border: 'none',
+											background: 'transparent',
+											color: colors.textMuted,
+											cursor: 'pointer',
+										}),
+										on<HTMLElement, 'click'>('click', closeTransactionModal),
+									]}
+								>
+									Close
+								</button>
+							</header>
+
+							<label mix={css({ display: 'grid', gap: spacing.xs })}>
+								<span mix={css({ color: colors.text })}>Amount</span>
+								<input
+									type="number"
+									min="0"
+									step="0.01"
+									value={transactionState.amount}
+									mix={[
+										css(inputCss),
+										on<HTMLElement, 'input'>('input', (event) => {
+											if (!(event.currentTarget instanceof HTMLInputElement))
+												return
+											transactionState!.amount = event.currentTarget.value
+											transactionState!.error = null
+											handle.update()
+										}),
+									]}
+								/>
+							</label>
+
+							<div mix={css({ display: 'grid', gap: spacing.xs })}>
+								<span
+									mix={css({
+										color: colors.textMuted,
+										fontSize: typography.fontSize.sm,
+									})}
+								>
+									Quick amounts
+								</span>
+								<div
 									mix={css({
 										display: 'grid',
-										gridTemplateColumns: '1fr',
-										gap: spacing.sm,
-										alignItems: 'stretch',
-										padding: spacing.xs,
-										borderRadius: radius.lg,
-										background: getAccountGradientBackground(
-											account.colorToken,
-										),
-										color: '#ffffff',
-										boxShadow: `0 4px 0 0 rgba(0,0,0,0.2)`,
-										[mq.mobile]: {
-											gridTemplateColumns: '1fr',
-										},
+										gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+										gap: spacing.xs,
 									})}
 								>
 									<button
 										type="button"
+										disabled={
+											Math.abs(transactionState!.account.balanceCents) === 0
+										}
 										mix={[
-											css({
-												display: 'flex',
-												justifyContent: 'space-between',
-												alignItems: 'center',
-												gap: spacing.sm,
-												minWidth: 0,
-												padding: spacing.sm,
-												border: 'none',
-												borderRadius: radius.md,
-												background: 'transparent',
-												color: 'inherit',
-												cursor: 'pointer',
-												textAlign: 'left',
-												transition: `background-color ${transitions.fast}`,
-												'&:hover': {
-													backgroundColor: 'rgba(255,255,255,0.14)',
-												},
-											}),
-											on<HTMLElement, 'click'>('click', (event) => {
-												if (!(event.currentTarget instanceof HTMLButtonElement))
-													return
-												openTransactionModal(kid, account, event.currentTarget)
-											}),
+											css(quickAmountButtonCss()),
+											on<HTMLElement, 'click'>('click', () =>
+												setTransactionAmountFromQuick(
+													Math.abs(transactionState!.account.balanceCents),
+												),
+											),
 										]}
 									>
-										<span
-											mix={css({
-												display: 'grid',
-												gap: 2,
-												minWidth: 0,
-												fontWeight: typography.fontWeight.semibold,
-											})}
-										>
-											{account.name}
-											<span
-												mix={css({
-													fontSize: typography.fontSize.sm,
-													opacity: 0.9,
-												})}
-											>
-												Tap to add or remove money
-											</span>
-											{interestPreviewText ? (
-												<span
-													mix={css({
-														fontSize: typography.fontSize.sm,
-														fontWeight: typography.fontWeight.normal,
-														opacity: 0.9,
-													})}
-												>
-													{interestPreviewText}
-												</span>
-											) : null}
-										</span>
-										<strong
-											mix={css({
-												flexShrink: 0,
-												fontSize: typography.fontSize.lg,
-											})}
-										>
-											{formatCents(account.balanceCents)}
-										</strong>
+										{`Current Total (${formatCents(
+											transactionState.account.balanceCents,
+										)})`}
 									</button>
-								</article>
-							)
-						})}
-					</div>
-				</article>
-			))}
-
-			{status === 'ready' ? (
-				<section
-					mix={css({
-						display: 'grid',
-						gap: spacing.sm,
-						padding: spacing.lg,
-						borderRadius: radius.xl,
-						border: `3px solid ${colors.border}`,
-						backgroundColor: colors.surface,
-						boxShadow: shadows.md,
-						textAlign: 'center',
-					})}
-				>
-					<h2 mix={css({ margin: 0, color: colors.text })}>
-						Move money around
-					</h2>
-					<p mix={css({ margin: 0, color: colors.textMuted })}>
-						Transfer between any two accounts. Same-kid accounts are suggested
-						first.
-					</p>
-					<button
-						type="button"
-						disabled={getTransferAccountOptions(kids).length < 2}
-						mix={[
-							css({
-								...buttonCss,
-								justifySelf: 'center',
-								minWidth: 'min(100%, 18rem)',
-								paddingInline: spacing.lg,
-							}),
-							on<HTMLElement, 'click'>('click', (event) => {
-								if (!(event.currentTarget instanceof HTMLButtonElement)) return
-								openTransferModal(event.currentTarget)
-							}),
-						]}
-					>
-						Transfer money
-					</button>
-				</section>
-			) : null}
-
-			{transactionState ? (
-				<div
-					mix={[
-						css({
-							position: 'fixed',
-							inset: 0,
-							backgroundColor: 'rgba(0, 0, 0, 0.45)',
-							display: 'grid',
-							placeItems: 'center',
-							padding: spacing.md,
-							zIndex: 1000,
-							pointerEvents: transactionModalClosing ? 'none' : 'auto',
-							animation: transactionModalClosing
-								? `modal-backdrop-out ${modalCloseAnimationDurationMs}ms ease-in forwards`
-								: 'modal-backdrop-in 180ms ease-out forwards',
-							[mq.mobile]: {
-								padding: 0,
-								placeItems: 'stretch',
-							},
-						}),
-						on<HTMLElement, 'click'>('click', (event) => {
-							if (event.target === event.currentTarget) {
-								closeTransactionModal()
-							}
-						}),
-					]}
-				>
-					{transactionState.kid.transactionModalCss.trim() ? (
-						<style data-kid-transaction-modal-css>
-							{buildTransactionModalCss(
-								transactionState.kid.transactionModalCss,
-							)}
-						</style>
-					) : null}
-					<section
-						role="dialog"
-						aria-modal="true"
-						aria-labelledby="transaction-modal-title"
-						aria-describedby="transaction-modal-description"
-						data-kid-transaction-modal
-						mix={[
-							css({
-								width: 'min(30rem, 100%)',
-								maxHeight: 'calc(100dvh - 2 * var(--spacing-md))',
-								overflow: 'auto',
-								display: 'grid',
-								gap: spacing.md,
-								padding: spacing.lg,
-								fontFamily: typography.fontFamily,
-								borderRadius: radius.xl,
-								border: `3px solid ${colors.border}`,
-								backgroundColor: colors.surface,
-								boxShadow: shadows.lg,
-								animation: transactionModalClosing
-									? `modal-close ${modalCloseAnimationDurationMs}ms ease-in forwards`
-									: 'modal-pop 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards',
-								[mq.mobile]: {
-									width: '100%',
-									maxHeight: '100dvh',
-									minHeight: '100dvh',
-									borderRadius: 0,
-									border: 'none',
-									gap: spacing.sm,
-									padding: spacing.md,
-								},
-							}),
-							on<HTMLElement, 'keydown'>(
-								'keydown',
-								handleTransactionModalKeydown,
-							),
-						]}
-					>
-						<header
-							mix={css({ display: 'flex', justifyContent: 'space-between' })}
-						>
-							<div>
-								<h3
-									id="transaction-modal-title"
-									mix={css({ margin: 0, color: colors.text })}
-								>
-									{transactionState.kid.emoji} {transactionState.kid.name}
-								</h3>
-								<p
-									id="transaction-modal-description"
-									mix={css({ margin: 0, color: colors.textMuted })}
-								>
-									{transactionState.account.name} ·{' '}
-									{formatCents(transactionState.account.balanceCents)}
-								</p>
+									{quickAmounts.map((amount) => (
+										<button
+											key={amount}
+											type="button"
+											mix={[
+												css(quickAmountButtonCss()),
+												on<HTMLElement, 'click'>('click', () =>
+													setTransactionAmountFromQuick(amount),
+												),
+											]}
+										>
+											{formatCents(amount)}
+										</button>
+									))}
+								</div>
 							</div>
-							<button
-								id="transaction-modal-close"
-								type="button"
-								mix={[
-									css({
-										border: 'none',
-										background: 'transparent',
-										color: colors.textMuted,
-										cursor: 'pointer',
-									}),
-									on<HTMLElement, 'click'>('click', closeTransactionModal),
-								]}
-							>
-								Close
-							</button>
-						</header>
 
-						<label mix={css({ display: 'grid', gap: spacing.xs })}>
-							<span mix={css({ color: colors.text })}>Amount</span>
-							<input
-								type="number"
-								min="0"
-								step="0.01"
-								value={transactionState.amount}
-								mix={[
-									css(inputCss),
-									on<HTMLElement, 'input'>('input', (event) => {
-										if (!(event.currentTarget instanceof HTMLInputElement))
-											return
-										transactionState!.amount = event.currentTarget.value
-										transactionState!.error = null
-										handle.update()
-									}),
-								]}
-							/>
-						</label>
+							<label mix={css({ display: 'grid', gap: spacing.xs })}>
+								<span mix={css({ color: colors.text })}>Note (optional)</span>
+								<input
+									type="text"
+									value={transactionState.note}
+									mix={[
+										css(inputCss),
+										on<HTMLElement, 'input'>('input', (event) => {
+											if (!(event.currentTarget instanceof HTMLInputElement))
+												return
+											transactionState!.note = event.currentTarget.value
+											handle.update()
+										}),
+									]}
+								/>
+							</label>
 
-						<div mix={css({ display: 'grid', gap: spacing.xs })}>
-							<span
-								mix={css({
-									color: colors.textMuted,
-									fontSize: typography.fontSize.sm,
-								})}
-							>
-								Quick amounts
-							</span>
+							{transactionState.error ? (
+								<p mix={css({ margin: 0, color: colors.error })}>
+									{transactionState.error}
+								</p>
+							) : null}
+							{transactionState.warning ? (
+								<p mix={css({ margin: 0, color: '#b45309' })}>
+									{transactionState.warning}
+								</p>
+							) : null}
+
 							<div
 								mix={css({
 									display: 'grid',
 									gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-									gap: spacing.xs,
+									gap: spacing.sm,
 								})}
 							>
 								<button
 									type="button"
-									disabled={
-										Math.abs(transactionState!.account.balanceCents) === 0
-									}
 									mix={[
-										css(quickAmountButtonCss()),
-										on<HTMLElement, 'click'>('click', () =>
-											setTransactionAmountFromQuick(
-												Math.abs(transactionState!.account.balanceCents),
+										css({
+											...modalButtonCss(
+												colors.surface,
+												colors.text,
+												colors.border,
 											),
+											border: `2px solid ${colors.border}`,
+										}),
+										on<HTMLElement, 'click'>('click', closeTransactionModal),
+									]}
+								>
+									Cancel
+								</button>
+								<button
+									type="button"
+									disabled={transactionState.status === 'saving'}
+									mix={[
+										css(modalButtonCss('#86efac', '#052e16', '#16a34a')),
+										on<HTMLElement, 'click'>(
+											'click',
+											() => void submitTransaction('add'),
 										),
 									]}
 								>
-									{`Current Total (${formatCents(
-										transactionState.account.balanceCents,
-									)})`}
+									Add
 								</button>
-								{quickAmounts.map((amount) => (
-									<button
-										key={amount}
-										type="button"
-										mix={[
-											css(quickAmountButtonCss()),
-											on<HTMLElement, 'click'>('click', () =>
-												setTransactionAmountFromQuick(amount),
-											),
-										]}
-									>
-										{formatCents(amount)}
-									</button>
-								))}
-							</div>
-						</div>
-
-						<label mix={css({ display: 'grid', gap: spacing.xs })}>
-							<span mix={css({ color: colors.text })}>Note (optional)</span>
-							<input
-								type="text"
-								value={transactionState.note}
-								mix={[
-									css(inputCss),
-									on<HTMLElement, 'input'>('input', (event) => {
-										if (!(event.currentTarget instanceof HTMLInputElement))
-											return
-										transactionState!.note = event.currentTarget.value
-										handle.update()
-									}),
-								]}
-							/>
-						</label>
-
-						{transactionState.error ? (
-							<p mix={css({ margin: 0, color: colors.error })}>
-								{transactionState.error}
-							</p>
-						) : null}
-						{transactionState.warning ? (
-							<p mix={css({ margin: 0, color: '#b45309' })}>
-								{transactionState.warning}
-							</p>
-						) : null}
-
-						<div
-							mix={css({
-								display: 'grid',
-								gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-								gap: spacing.sm,
-							})}
-						>
-							<button
-								type="button"
-								mix={[
-									css({
-										...modalButtonCss(
-											colors.surface,
-											colors.text,
-											colors.border,
+								<button
+									type="button"
+									disabled={transactionState.status === 'saving'}
+									mix={[
+										css(modalButtonCss('#fecaca', '#450a0a', '#dc2626')),
+										on<HTMLElement, 'click'>(
+											'click',
+											() => void submitTransaction('remove'),
 										),
-										border: `2px solid ${colors.border}`,
-									}),
-									on<HTMLElement, 'click'>('click', closeTransactionModal),
-								]}
-							>
-								Cancel
-							</button>
-							<button
-								type="button"
-								disabled={transactionState.status === 'saving'}
-								mix={[
-									css(modalButtonCss('#86efac', '#052e16', '#16a34a')),
-									on<HTMLElement, 'click'>(
-										'click',
-										() => void submitTransaction('add'),
-									),
-								]}
-							>
-								Add
-							</button>
-							<button
-								type="button"
-								disabled={transactionState.status === 'saving'}
-								mix={[
-									css(modalButtonCss('#fecaca', '#450a0a', '#dc2626')),
-									on<HTMLElement, 'click'>(
-										'click',
-										() => void submitTransaction('remove'),
-									),
-								]}
-							>
-								Remove
-							</button>
-						</div>
-					</section>
-				</div>
-			) : null}
+									]}
+								>
+									Remove
+								</button>
+							</div>
+						</section>
+					</div>
+				) : null}
 
-			{transferState ? (
-				<div
-					mix={[
-						css({
-							position: 'fixed',
-							inset: 0,
-							backgroundColor: 'rgba(0, 0, 0, 0.45)',
-							display: 'grid',
-							placeItems: 'center',
-							padding: spacing.md,
-							zIndex: 1000,
-							pointerEvents: transferModalClosing ? 'none' : 'auto',
-							animation: transferModalClosing
-								? `modal-backdrop-out ${modalCloseAnimationDurationMs}ms ease-in forwards`
-								: 'modal-backdrop-in 180ms ease-out forwards',
-							[mq.mobile]: {
-								padding: 0,
-								placeItems: 'stretch',
-							},
-						}),
-						on<HTMLElement, 'click'>('click', (event) => {
-							if (event.target === event.currentTarget) {
-								closeTransferModal()
-							}
-						}),
-					]}
-				>
-					<section
-						role="dialog"
-						aria-modal="true"
-						aria-labelledby="transfer-modal-title"
-						aria-describedby="transfer-modal-description"
+				{transferState ? (
+					<div
 						mix={[
 							css({
-								width: 'min(34rem, 100%)',
-								maxHeight: 'calc(100dvh - 2 * var(--spacing-md))',
-								overflow: 'auto',
+								position: 'fixed',
+								inset: 0,
+								backgroundColor: 'rgba(0, 0, 0, 0.45)',
 								display: 'grid',
-								gap: spacing.md,
-								padding: spacing.lg,
-								fontFamily: typography.fontFamily,
-								borderRadius: radius.xl,
-								border: `3px solid ${colors.border}`,
-								backgroundColor: colors.surface,
-								boxShadow: shadows.lg,
+								placeItems: 'center',
+								padding: spacing.md,
+								zIndex: 1000,
+								pointerEvents: transferModalClosing ? 'none' : 'auto',
 								animation: transferModalClosing
-									? `modal-close ${modalCloseAnimationDurationMs}ms ease-in forwards`
-									: 'modal-pop 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards',
+									? `modal-backdrop-out ${modalCloseAnimationDurationMs}ms ease-in forwards`
+									: 'modal-backdrop-in 180ms ease-out forwards',
 								[mq.mobile]: {
-									width: '100%',
-									maxHeight: '100dvh',
-									minHeight: '100dvh',
-									borderRadius: 0,
-									border: 'none',
-									gap: spacing.sm,
-									padding: spacing.md,
+									padding: 0,
+									placeItems: 'stretch',
 								},
 							}),
-							on<HTMLElement, 'keydown'>('keydown', handleTransferModalKeydown),
+							on<HTMLElement, 'click'>('click', (event) => {
+								if (event.target === event.currentTarget) {
+									closeTransferModal()
+								}
+							}),
 						]}
 					>
-						<header
-							mix={css({ display: 'flex', justifyContent: 'space-between' })}
-						>
-							<div>
-								<h3
-									id="transfer-modal-title"
-									mix={css({ margin: 0, color: colors.text })}
-								>
-									Transfer money
-								</h3>
-								<p
-									id="transfer-modal-description"
-									mix={css({ margin: 0, color: colors.textMuted })}
-								>
-									Move any amount from one account to another.
-								</p>
-							</div>
-							<button
-								id="transfer-modal-close"
-								type="button"
-								mix={[
-									css({
+						<section
+							role="dialog"
+							aria-modal="true"
+							aria-labelledby="transfer-modal-title"
+							aria-describedby="transfer-modal-description"
+							mix={[
+								css({
+									width: 'min(34rem, 100%)',
+									maxHeight: 'calc(100dvh - 2 * var(--spacing-md))',
+									overflow: 'auto',
+									display: 'grid',
+									gap: spacing.md,
+									padding: spacing.lg,
+									fontFamily: typography.fontFamily,
+									borderRadius: radius.xl,
+									border: `3px solid ${colors.border}`,
+									backgroundColor: colors.surface,
+									boxShadow: shadows.lg,
+									animation: transferModalClosing
+										? `modal-close ${modalCloseAnimationDurationMs}ms ease-in forwards`
+										: 'modal-pop 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards',
+									[mq.mobile]: {
+										width: '100%',
+										maxHeight: '100dvh',
+										minHeight: '100dvh',
+										borderRadius: 0,
 										border: 'none',
-										background: 'transparent',
-										color: colors.textMuted,
-										cursor: 'pointer',
-									}),
-									on<HTMLElement, 'click'>('click', closeTransferModal),
-								]}
+										gap: spacing.sm,
+										padding: spacing.md,
+									},
+								}),
+								on<HTMLElement, 'keydown'>(
+									'keydown',
+									handleTransferModalKeydown,
+								),
+							]}
+						>
+							<header
+								mix={css({ display: 'flex', justifyContent: 'space-between' })}
 							>
-								Close
-							</button>
-						</header>
-
-						<label mix={css({ display: 'grid', gap: spacing.xs })}>
-							<span mix={css({ color: colors.text })}>From account</span>
-							<select
-								value={transferState.fromAccountId}
-								disabled={getTransferAccountOptions(kids).length === 0}
-								mix={[
-									css(inputCss),
-									on<HTMLElement, 'change'>('change', (event) => {
-										if (!(event.currentTarget instanceof HTMLSelectElement))
-											return
-										setTransferSource(event.currentTarget.value)
-									}),
-								]}
-							>
-								{getTransferAccountGroups(kids).map((group) => (
-									<optgroup
-										key={group.kid.id}
-										label={`${group.kid.emoji} ${group.kid.name}`}
+								<div>
+									<h3
+										id="transfer-modal-title"
+										mix={css({ margin: 0, color: colors.text })}
 									>
-										{group.accounts.map((account) => (
-											<option key={account.id} value={String(account.id)}>
-												{account.name} ({formatCents(account.balanceCents)})
-											</option>
-										))}
-									</optgroup>
-								))}
-							</select>
-							<span
-								mix={css({
-									color: colors.textMuted,
-									fontSize: typography.fontSize.sm,
-								})}
-							>
-								{getSelectedTransferSourceBalanceLabel(transferState, kids)}
-							</span>
-						</label>
+										Transfer money
+									</h3>
+									<p
+										id="transfer-modal-description"
+										mix={css({ margin: 0, color: colors.textMuted })}
+									>
+										Move any amount from one account to another.
+									</p>
+								</div>
+								<button
+									id="transfer-modal-close"
+									type="button"
+									mix={[
+										css({
+											border: 'none',
+											background: 'transparent',
+											color: colors.textMuted,
+											cursor: 'pointer',
+										}),
+										on<HTMLElement, 'click'>('click', closeTransferModal),
+									]}
+								>
+									Close
+								</button>
+							</header>
 
-						<label mix={css({ display: 'grid', gap: spacing.xs })}>
-							<span mix={css({ color: colors.text })}>To account</span>
-							<select
-								value={transferState.toAccountId}
-								disabled={
-									getTransferDestinationGroups(transferState, kids).length === 0
-								}
-								mix={[
-									css(inputCss),
-									on<HTMLElement, 'change'>('change', (event) => {
-										if (!(event.currentTarget instanceof HTMLSelectElement))
-											return
-										transferState!.toAccountId = event.currentTarget.value
-										transferState!.error = null
-										handle.update()
-									}),
-								]}
-							>
-								{getTransferDestinationGroups(transferState, kids).map(
-									(group) => (
+							<label mix={css({ display: 'grid', gap: spacing.xs })}>
+								<span mix={css({ color: colors.text })}>From account</span>
+								<select
+									value={transferState.fromAccountId}
+									disabled={getTransferAccountOptions(kids).length === 0}
+									mix={[
+										css(inputCss),
+										on<HTMLElement, 'change'>('change', (event) => {
+											if (!(event.currentTarget instanceof HTMLSelectElement))
+												return
+											setTransferSource(event.currentTarget.value)
+										}),
+									]}
+								>
+									{getTransferAccountGroups(kids).map((group) => (
 										<optgroup
 											key={group.kid.id}
 											label={`${group.kid.emoji} ${group.kid.name}`}
@@ -1032,158 +1040,206 @@ export function HomeRoute(handle: Handle) {
 												</option>
 											))}
 										</optgroup>
-									),
-								)}
-							</select>
-							<span
-								mix={css({
-									color: colors.textMuted,
-									fontSize: typography.fontSize.sm,
-								})}
-							>
-								Accounts for{' '}
-								{getSelectedTransferSource(transferState, kids)?.kid.name ??
-									'the selected kid'}{' '}
-								are listed first; other kids are available below.
-							</span>
-						</label>
+									))}
+								</select>
+								<span
+									mix={css({
+										color: colors.textMuted,
+										fontSize: typography.fontSize.sm,
+									})}
+								>
+									{getSelectedTransferSourceBalanceLabel(transferState, kids)}
+								</span>
+							</label>
 
-						<label mix={css({ display: 'grid', gap: spacing.xs })}>
-							<span mix={css({ color: colors.text })}>Amount</span>
-							<input
-								type="number"
-								min="0"
-								step="0.01"
-								value={transferState.amount}
-								mix={[
-									css(inputCss),
-									on<HTMLElement, 'input'>('input', (event) => {
-										if (!(event.currentTarget instanceof HTMLInputElement))
-											return
-										transferState!.amount = event.currentTarget.value
-										transferState!.error = null
-										handle.update()
-									}),
-								]}
-							/>
-						</label>
+							<label mix={css({ display: 'grid', gap: spacing.xs })}>
+								<span mix={css({ color: colors.text })}>To account</span>
+								<select
+									value={transferState.toAccountId}
+									disabled={
+										getTransferDestinationGroups(transferState, kids).length ===
+										0
+									}
+									mix={[
+										css(inputCss),
+										on<HTMLElement, 'change'>('change', (event) => {
+											if (!(event.currentTarget instanceof HTMLSelectElement))
+												return
+											transferState!.toAccountId = event.currentTarget.value
+											transferState!.error = null
+											handle.update()
+										}),
+									]}
+								>
+									{getTransferDestinationGroups(transferState, kids).map(
+										(group) => (
+											<optgroup
+												key={group.kid.id}
+												label={`${group.kid.emoji} ${group.kid.name}`}
+											>
+												{group.accounts.map((account) => (
+													<option key={account.id} value={String(account.id)}>
+														{account.name} ({formatCents(account.balanceCents)})
+													</option>
+												))}
+											</optgroup>
+										),
+									)}
+								</select>
+								<span
+									mix={css({
+										color: colors.textMuted,
+										fontSize: typography.fontSize.sm,
+									})}
+								>
+									Accounts for{' '}
+									{getSelectedTransferSource(transferState, kids)?.kid.name ??
+										'the selected kid'}{' '}
+									are listed first; other kids are available below.
+								</span>
+							</label>
 
-						<div mix={css({ display: 'grid', gap: spacing.xs })}>
-							<span
-								mix={css({
-									color: colors.textMuted,
-									fontSize: typography.fontSize.sm,
-								})}
-							>
-								Quick amounts
-							</span>
+							<label mix={css({ display: 'grid', gap: spacing.xs })}>
+								<span mix={css({ color: colors.text })}>Amount</span>
+								<input
+									type="number"
+									min="0"
+									step="0.01"
+									value={transferState.amount}
+									mix={[
+										css(inputCss),
+										on<HTMLElement, 'input'>('input', (event) => {
+											if (!(event.currentTarget instanceof HTMLInputElement))
+												return
+											transferState!.amount = event.currentTarget.value
+											transferState!.error = null
+											handle.update()
+										}),
+									]}
+								/>
+							</label>
+
+							<div mix={css({ display: 'grid', gap: spacing.xs })}>
+								<span
+									mix={css({
+										color: colors.textMuted,
+										fontSize: typography.fontSize.sm,
+									})}
+								>
+									Quick amounts
+								</span>
+								<div
+									mix={css({
+										display: 'grid',
+										gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+										gap: spacing.xs,
+									})}
+								>
+									<button
+										type="button"
+										disabled={
+											getTransferAvailableBalanceCents(transferState, kids) ===
+											0
+										}
+										mix={[
+											css(quickAmountButtonCss()),
+											on<HTMLElement, 'click'>('click', () =>
+												setTransferAmountFromQuick(
+													getTransferAvailableBalanceCents(
+														transferState!,
+														kids,
+													),
+												),
+											),
+										]}
+									>
+										{`Current Total (${formatCents(
+											getTransferAvailableBalanceCents(transferState, kids),
+										)})`}
+									</button>
+									{quickAmounts.map((amount) => (
+										<button
+											key={amount}
+											type="button"
+											mix={[
+												css(quickAmountButtonCss()),
+												on<HTMLElement, 'click'>('click', () =>
+													setTransferAmountFromQuick(amount),
+												),
+											]}
+										>
+											{formatCents(amount)}
+										</button>
+									))}
+								</div>
+							</div>
+
+							<label mix={css({ display: 'grid', gap: spacing.xs })}>
+								<span mix={css({ color: colors.text })}>Note (optional)</span>
+								<input
+									type="text"
+									value={transferState.note}
+									mix={[
+										css(inputCss),
+										on<HTMLElement, 'input'>('input', (event) => {
+											if (!(event.currentTarget instanceof HTMLInputElement))
+												return
+											transferState!.note = event.currentTarget.value
+											handle.update()
+										}),
+									]}
+								/>
+							</label>
+
+							{transferState.error ? (
+								<p mix={css({ margin: 0, color: colors.error })}>
+									{transferState.error}
+								</p>
+							) : null}
+
 							<div
 								mix={css({
 									display: 'grid',
-									gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-									gap: spacing.xs,
+									gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+									gap: spacing.sm,
 								})}
 							>
 								<button
 									type="button"
-									disabled={
-										getTransferAvailableBalanceCents(transferState, kids) === 0
-									}
 									mix={[
-										css(quickAmountButtonCss()),
-										on<HTMLElement, 'click'>('click', () =>
-											setTransferAmountFromQuick(
-												getTransferAvailableBalanceCents(transferState!, kids),
+										css({
+											...modalButtonCss(
+												colors.surface,
+												colors.text,
+												colors.border,
 											),
+											border: `2px solid ${colors.border}`,
+										}),
+										on<HTMLElement, 'click'>('click', closeTransferModal),
+									]}
+								>
+									Cancel
+								</button>
+								<button
+									type="button"
+									disabled={transferState.status === 'saving'}
+									mix={[
+										css(modalButtonCss('#bfdbfe', '#172554', '#2563eb')),
+										on<HTMLElement, 'click'>(
+											'click',
+											() => void submitTransfer(),
 										),
 									]}
 								>
-									{`Current Total (${formatCents(
-										getTransferAvailableBalanceCents(transferState, kids),
-									)})`}
+									Transfer
 								</button>
-								{quickAmounts.map((amount) => (
-									<button
-										key={amount}
-										type="button"
-										mix={[
-											css(quickAmountButtonCss()),
-											on<HTMLElement, 'click'>('click', () =>
-												setTransferAmountFromQuick(amount),
-											),
-										]}
-									>
-										{formatCents(amount)}
-									</button>
-								))}
 							</div>
-						</div>
-
-						<label mix={css({ display: 'grid', gap: spacing.xs })}>
-							<span mix={css({ color: colors.text })}>Note (optional)</span>
-							<input
-								type="text"
-								value={transferState.note}
-								mix={[
-									css(inputCss),
-									on<HTMLElement, 'input'>('input', (event) => {
-										if (!(event.currentTarget instanceof HTMLInputElement))
-											return
-										transferState!.note = event.currentTarget.value
-										handle.update()
-									}),
-								]}
-							/>
-						</label>
-
-						{transferState.error ? (
-							<p mix={css({ margin: 0, color: colors.error })}>
-								{transferState.error}
-							</p>
-						) : null}
-
-						<div
-							mix={css({
-								display: 'grid',
-								gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-								gap: spacing.sm,
-							})}
-						>
-							<button
-								type="button"
-								mix={[
-									css({
-										...modalButtonCss(
-											colors.surface,
-											colors.text,
-											colors.border,
-										),
-										border: `2px solid ${colors.border}`,
-									}),
-									on<HTMLElement, 'click'>('click', closeTransferModal),
-								]}
-							>
-								Cancel
-							</button>
-							<button
-								type="button"
-								disabled={transferState.status === 'saving'}
-								mix={[
-									css(modalButtonCss('#bfdbfe', '#172554', '#2563eb')),
-									on<HTMLElement, 'click'>(
-										'click',
-										() => void submitTransfer(),
-									),
-								]}
-							>
-								Transfer
-							</button>
-						</div>
-					</section>
-				</div>
-			) : null}
-		</section>
-	)
+						</section>
+					</div>
+				) : null}
+			</section>
+		)
+	}
 }
 
 export const Component = HomeRoute

--- a/client/routes/home.tsx
+++ b/client/routes/home.tsx
@@ -1,4 +1,5 @@
 import { css, on, type Handle } from 'remix/ui'
+import { readAppSession } from '#client/app-session.tsx'
 import {
 	createTransaction,
 	createTransfer,
@@ -75,9 +76,14 @@ function getInterestPreviewText(account: KidAccount) {
 }
 
 export function HomeRoute(handle: Handle) {
-	let status: 'loading' | 'ready' | 'error' = 'loading'
+	const appSession = readAppSession(handle)
+	const isLoggedOutSsr =
+		appSession.status === 'ready' && appSession.session === null
+	let status: 'loading' | 'ready' | 'error' = isLoggedOutSsr
+		? 'error'
+		: 'loading'
 	let errorMessage = ''
-	let needsLogin = false
+	let needsLogin = isLoggedOutSsr
 	let kids: Array<KidSummary> = []
 	let familyBalance = 0
 	let quickAmounts: Array<number> = []
@@ -248,6 +254,13 @@ export function HomeRoute(handle: Handle) {
 	}
 
 	handle.queueTask(async () => {
+		const nextAppSession = readAppSession(handle)
+		if (nextAppSession.status === 'ready' && nextAppSession.session === null) {
+			status = 'error'
+			needsLogin = true
+			handle.update()
+			return
+		}
 		await refreshDashboard()
 	})
 	handle.queueTask(() => {

--- a/client/routes/index.tsx
+++ b/client/routes/index.tsx
@@ -11,6 +11,7 @@ import * as resetPassword from './reset-password.tsx'
 import * as settings from './settings.tsx'
 import * as signup from './signup.tsx'
 import * as termsOfService from './terms-of-service.tsx'
+import { type ClientRouteLoader } from '#client/route-loader-data.tsx'
 
 const appTitle = 'Kids Ledger'
 
@@ -22,6 +23,7 @@ type MetaData = {
 
 type RouteModule = {
 	Component: (...args: Array<any>) => any
+	loader?: ClientRouteLoader
 	getMetadata?: (args: { url: URL; params: RouteParams }) => MetaData
 }
 

--- a/client/routes/login.tsx
+++ b/client/routes/login.tsx
@@ -2,6 +2,11 @@ import { css, on, type Handle } from 'remix/ui'
 import { buildAuthLink } from '#client/auth-links.ts'
 import { navigate } from '#client/client-router.tsx'
 import { getErrorMessage, parseJsonOrNull } from '#client/http.ts'
+import {
+	tryConsumeRouteLoaderData,
+	type ClientRouteLoader,
+} from '#client/route-loader-data.tsx'
+import { readRouterSearch, readRouterUrl } from '#client/router-location.tsx'
 import { fetchSessionInfo, type SessionStatus } from '#client/session.ts'
 import { normalizeRedirectTarget } from '#shared/redirect-target.ts'
 import {
@@ -21,15 +26,17 @@ type LoginFormSetup = {
 	initialMode?: AuthMode
 }
 
-function getSearchParams() {
-	return typeof window === 'undefined'
-		? new URLSearchParams()
-		: new URLSearchParams(window.location.search)
+function getSearchParams(handle: Handle) {
+	return new URLSearchParams(readRouterSearch(handle))
 }
 
 function buildAuthPath(mode: AuthMode, redirectTo: string | null) {
 	const path = mode === 'signup' ? '/signup' : '/login'
 	return buildAuthLink(path, redirectTo)
+}
+
+export const loader: ClientRouteLoader = async ({ signal }) => {
+	return { session: await fetchSessionInfo(signal) }
 }
 
 export function LoginRoute(handle: Handle, setup: LoginFormSetup = {}) {
@@ -39,9 +46,10 @@ export function LoginRoute(handle: Handle, setup: LoginFormSetup = {}) {
 	let sessionStatus: SessionStatus = 'idle'
 	let sessionEmail = ''
 	const redirectTo = normalizeRedirectTarget(
-		getSearchParams().get('redirectTo'),
+		getSearchParams(handle).get('redirectTo'),
 	)
 	const redirectTarget = redirectTo ?? '/account'
+	let sessionRefreshInFlight = false
 
 	function setState(nextStatus: AuthStatus, nextMessage: string | null = null) {
 		status = nextStatus
@@ -58,21 +66,33 @@ export function LoginRoute(handle: Handle, setup: LoginFormSetup = {}) {
 		handle.update()
 	}
 
-	handle.queueTask(async (signal) => {
-		if (sessionStatus !== 'idle') return
-		sessionStatus = 'loading'
-
-		const session = await fetchSessionInfo(signal)
-		if (signal.aborted) return
+	function applySession(session: Awaited<ReturnType<typeof fetchSessionInfo>>) {
 		sessionEmail = session?.email ?? ''
-
 		sessionStatus = 'ready'
 		if (sessionEmail && typeof window !== 'undefined') {
 			window.location.assign(redirectTarget)
-			return
 		}
-		handle.update()
-	})
+	}
+
+	function applyRouteLoaderData(currentHref: string) {
+		const session = tryConsumeRouteLoaderData(handle, 'session', currentHref)
+		if (session === undefined) return false
+		applySession(session)
+		return true
+	}
+
+	async function loadSession(signal: AbortSignal) {
+		if (sessionStatus !== 'idle' || sessionRefreshInFlight) return
+		sessionRefreshInFlight = true
+		sessionStatus = 'loading'
+
+		const session = await fetchSessionInfo(signal)
+		if (!signal.aborted) {
+			applySession(session)
+			handle.update()
+		}
+		sessionRefreshInFlight = false
+	}
 
 	async function handleSubmit(event: SubmitEvent) {
 		event.preventDefault()
@@ -114,6 +134,15 @@ export function LoginRoute(handle: Handle, setup: LoginFormSetup = {}) {
 	}
 
 	return () => {
+		const currentHref = readRouterUrl(handle)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		if (
+			sessionStatus === 'idle' &&
+			!appliedRouteData &&
+			!sessionRefreshInFlight
+		) {
+			handle.queueTask(loadSession)
+		}
 		const isSignup = mode === 'signup'
 		const isSubmitting = status === 'submitting'
 		const title = isSignup ? 'Create your account' : 'Welcome back'

--- a/client/routes/oauth-authorize.tsx
+++ b/client/routes/oauth-authorize.tsx
@@ -109,10 +109,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 
 		try {
 			const data = await fetchOAuthAuthorizeLoaderData(readRouterSearch(handle))
-			applyOAuthAuthorizeData(data)
-			if (queryError && !data.error) {
-				message = { type: 'error', text: queryError }
-			}
+			applyOAuthAuthorizeData(data, queryError)
 		} catch {
 			info = null
 			status = 'error'
@@ -137,7 +134,10 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		handle.update()
 	}
 
-	function applyOAuthAuthorizeData(data: OAuthAuthorizeLoaderData) {
+	function applyOAuthAuthorizeData(
+		data: OAuthAuthorizeLoaderData,
+		queryError = readQueryError(),
+	) {
 		session = data.session
 		sessionStatus = 'ready'
 		if (data.error || !data.info) {
@@ -151,7 +151,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		}
 		info = data.info
 		status = 'ready'
-		message = null
+		message = queryError ? { type: 'error', text: queryError } : null
 	}
 
 	function applyRouteLoaderData(currentSearch: string) {

--- a/client/routes/oauth-authorize.tsx
+++ b/client/routes/oauth-authorize.tsx
@@ -1,5 +1,9 @@
 import { css, on, type Handle } from 'remix/ui'
 import { getErrorMessage, parseJsonOrNull } from '#client/http.ts'
+import {
+	tryConsumeRouteLoaderData,
+	type ClientRouteLoader,
+} from '#client/route-loader-data.tsx'
 import { readRouterSearch } from '#client/router-location.tsx'
 import {
 	fetchSessionInfo,
@@ -14,6 +18,7 @@ import {
 	typography,
 } from '#client/styles/tokens.ts'
 import { inputCss, buttonCss } from '#client/styles/form-controls.ts'
+import { type OAuthAuthorizeLoaderData } from '#shared/route-loader-data.ts'
 
 type OAuthAuthorizeInfo = {
 	client: { id: string; name: string }
@@ -27,6 +32,47 @@ function getSearchParams(handle: Handle) {
 	return new URLSearchParams(readRouterSearch(handle))
 }
 
+async function fetchOAuthAuthorizeLoaderData(
+	search: string,
+	signal?: AbortSignal,
+): Promise<OAuthAuthorizeLoaderData> {
+	const [infoResponse, session] = await Promise.all([
+		fetch(`/oauth/authorize-info${search}`, {
+			headers: { Accept: 'application/json' },
+			credentials: 'include',
+			signal,
+		}),
+		fetchSessionInfo(signal),
+	])
+	const payload = await parseJsonOrNull<{
+		ok?: boolean
+		error?: string
+		client?: OAuthAuthorizeInfo['client']
+		scopes?: OAuthAuthorizeInfo['scopes']
+	}>(infoResponse)
+	if (!infoResponse.ok || !payload?.ok || !payload.client) {
+		return {
+			info: null,
+			session,
+			error: getErrorMessage(payload, 'Unable to load authorization details.'),
+		}
+	}
+	return {
+		info: {
+			client: payload.client,
+			scopes: Array.isArray(payload.scopes) ? payload.scopes : [],
+		},
+		session,
+		error: null,
+	}
+}
+
+export const loader: ClientRouteLoader = async ({ url, signal }) => {
+	return {
+		oauthAuthorize: await fetchOAuthAuthorizeLoaderData(url.search, signal),
+	}
+}
+
 export function OAuthAuthorizeRoute(handle: Handle) {
 	let info: OAuthAuthorizeInfo | null = null
 	let status: OAuthAuthorizeStatus = 'idle'
@@ -35,6 +81,8 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 	let lastSearch = ''
 	let session: SessionInfo | null = null
 	let sessionStatus: SessionStatus = 'idle'
+	let infoRefreshInFlight = false
+	let sessionRefreshInFlight = false
 
 	function setMessage(next: OAuthAuthorizeMessage | null) {
 		message = next
@@ -50,6 +98,8 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 	}
 
 	async function loadInfo() {
+		if (infoRefreshInFlight) return
+		infoRefreshInFlight = true
 		status = 'loading'
 
 		const queryError = readQueryError()
@@ -58,47 +108,11 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		}
 
 		try {
-			const query = readRouterSearch(handle)
-			const response = await fetch(`/oauth/authorize-info${query}`, {
-				headers: { Accept: 'application/json' },
-				credentials: 'include',
-			})
-			const payload = await parseJsonOrNull<{
-				ok?: boolean
-				error?: string
-				client?: OAuthAuthorizeInfo['client']
-				scopes?: OAuthAuthorizeInfo['scopes']
-			}>(response)
-			if (!response.ok || !payload?.ok) {
-				const errorText = getErrorMessage(
-					payload,
-					'Unable to load authorization details.',
-				)
-				info = null
-				status = 'error'
-				message = { type: 'error', text: errorText }
-				handle.update()
-				return
+			const data = await fetchOAuthAuthorizeLoaderData(readRouterSearch(handle))
+			applyOAuthAuthorizeData(data)
+			if (queryError && !data.error) {
+				message = { type: 'error', text: queryError }
 			}
-			if (!payload.client || !Array.isArray(payload.scopes)) {
-				info = null
-				status = 'error'
-				message = {
-					type: 'error',
-					text: 'Unable to load authorization details.',
-				}
-				handle.update()
-				return
-			}
-			info = {
-				client: payload.client,
-				scopes: payload.scopes,
-			}
-			status = 'ready'
-			if (!queryError) {
-				message = null
-			}
-			handle.update()
 		} catch {
 			info = null
 			status = 'error'
@@ -106,18 +120,49 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 				type: 'error',
 				text: 'Unable to load authorization details.',
 			}
-			handle.update()
 		}
+		infoRefreshInFlight = false
+		handle.update()
 	}
 
 	async function loadSession() {
-		if (sessionStatus !== 'idle') return
+		if (sessionStatus !== 'idle' || sessionRefreshInFlight) return
+		sessionRefreshInFlight = true
 		sessionStatus = 'loading'
 
 		session = await fetchSessionInfo()
 
 		sessionStatus = 'ready'
+		sessionRefreshInFlight = false
 		handle.update()
+	}
+
+	function applyOAuthAuthorizeData(data: OAuthAuthorizeLoaderData) {
+		session = data.session
+		sessionStatus = 'ready'
+		if (data.error || !data.info) {
+			info = null
+			status = 'error'
+			message = {
+				type: 'error',
+				text: data.error ?? 'Unable to load authorization details.',
+			}
+			return
+		}
+		info = data.info
+		status = 'ready'
+		message = null
+	}
+
+	function applyRouteLoaderData(currentSearch: string) {
+		const data = tryConsumeRouteLoaderData(
+			handle,
+			'oauthAuthorize',
+			`/oauth/authorize${currentSearch}`,
+		)
+		if (!data) return false
+		applyOAuthAuthorizeData(data)
+		return true
 	}
 
 	async function submitDecision(
@@ -200,9 +245,15 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		const currentSearch = readRouterSearch(handle)
 		if (currentSearch !== lastSearch) {
 			lastSearch = currentSearch
-			void loadInfo()
+			if (!applyRouteLoaderData(currentSearch)) {
+				void loadInfo()
+			}
 		}
-		if (sessionStatus === 'idle') {
+		if (
+			sessionStatus === 'idle' &&
+			!infoRefreshInFlight &&
+			!sessionRefreshInFlight
+		) {
 			void loadSession()
 		}
 

--- a/client/routes/oauth-authorize.tsx
+++ b/client/routes/oauth-authorize.tsx
@@ -1,5 +1,6 @@
 import { css, on, type Handle } from 'remix/ui'
 import { getErrorMessage, parseJsonOrNull } from '#client/http.ts'
+import { readRouterSearch } from '#client/router-location.tsx'
 import {
 	fetchSessionInfo,
 	type SessionInfo,
@@ -22,10 +23,8 @@ type OAuthAuthorizeInfo = {
 type OAuthAuthorizeStatus = 'idle' | 'loading' | 'ready' | 'error'
 type OAuthAuthorizeMessage = { type: 'error' | 'info'; text: string }
 
-function getSearchParams() {
-	return typeof window === 'undefined'
-		? new URLSearchParams()
-		: new URLSearchParams(window.location.search)
+function getSearchParams(handle: Handle) {
+	return new URLSearchParams(readRouterSearch(handle))
 }
 
 export function OAuthAuthorizeRoute(handle: Handle) {
@@ -43,7 +42,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 	}
 
 	function readQueryError() {
-		const params = getSearchParams()
+		const params = getSearchParams(handle)
 		const description = params.get('error_description')
 		if (description) return description
 		const error = params.get('error')
@@ -59,7 +58,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 		}
 
 		try {
-			const query = typeof window === 'undefined' ? '' : window.location.search
+			const query = readRouterSearch(handle)
 			const response = await fetch(`/oauth/authorize-info${query}`, {
 				headers: { Accept: 'application/json' },
 				credentials: 'include',
@@ -198,8 +197,7 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 	}
 
 	return () => {
-		const currentSearch =
-			typeof window === 'undefined' ? '' : window.location.search
+		const currentSearch = readRouterSearch(handle)
 		if (currentSearch !== lastSearch) {
 			lastSearch = currentSearch
 			void loadInfo()

--- a/client/routes/oauth-authorize.tsx
+++ b/client/routes/oauth-authorize.tsx
@@ -314,119 +314,122 @@ export function OAuthAuthorizeRoute(handle: Handle) {
 						{message.text}
 					</p>
 				) : null}
-				<form
-					mix={[
-						css({
-							display: 'grid',
-							gap: spacing.md,
-							padding: spacing.lg,
-							borderRadius: radius.xl,
-							border: `3px solid ${colors.border}`,
-							backgroundColor: colors.surface,
-							boxShadow: shadows.md,
-							opacity: formReady ? 1 : 0.7,
-						}),
-						on<HTMLElement, 'submit'>('submit', handleSubmit),
-					]}
-				>
-					{!isLoggedIn && isSessionReady ? (
-						<>
-							<label mix={css({ display: 'grid', gap: spacing.xs })}>
-								<span
-									mix={css({
-										color: colors.text,
-										fontWeight: typography.fontWeight.medium,
-										fontSize: typography.fontSize.sm,
-									})}
-								>
-									Email
-								</span>
-								<input
-									type="email"
-									name="email"
-									required
-									autoComplete="email"
-									placeholder="you@example.com"
-									disabled={actionsDisabled}
-									mix={css({
-										...inputCss,
-										fontSize: typography.fontSize.base,
-										fontFamily: typography.fontFamily,
-									})}
-								/>
-							</label>
-							<label mix={css({ display: 'grid', gap: spacing.xs })}>
-								<span
-									mix={css({
-										color: colors.text,
-										fontWeight: typography.fontWeight.medium,
-										fontSize: typography.fontSize.sm,
-									})}
-								>
-									Password
-								</span>
-								<input
-									type="password"
-									name="password"
-									required
-									autoComplete="current-password"
-									placeholder="Enter your password"
-									disabled={actionsDisabled}
-									mix={css({
-										...inputCss,
-										fontSize: typography.fontSize.base,
-										fontFamily: typography.fontFamily,
-									})}
-								/>
-							</label>
-						</>
-					) : null}
-					<div
-						mix={css({ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' })}
+				{formReady ? (
+					<form
+						mix={[
+							css({
+								display: 'grid',
+								gap: spacing.md,
+								padding: spacing.lg,
+								borderRadius: radius.xl,
+								border: `3px solid ${colors.border}`,
+								backgroundColor: colors.surface,
+								boxShadow: shadows.md,
+							}),
+							on<HTMLElement, 'submit'>('submit', handleSubmit),
+						]}
 					>
-						<button
-							type="submit"
-							disabled={actionsDisabled}
-							mix={css({
-								...buttonCss,
-								padding: `${spacing.sm} ${spacing.lg}`,
-								borderRadius: radius.full,
-								fontSize: typography.fontSize.base,
-								cursor: actionsDisabled ? 'not-allowed' : 'pointer',
-								opacity: actionsDisabled ? 0.7 : 1,
-							})}
+						{!isLoggedIn && isSessionReady ? (
+							<>
+								<label mix={css({ display: 'grid', gap: spacing.xs })}>
+									<span
+										mix={css({
+											color: colors.text,
+											fontWeight: typography.fontWeight.medium,
+											fontSize: typography.fontSize.sm,
+										})}
+									>
+										Email
+									</span>
+									<input
+										type="email"
+										name="email"
+										required
+										autoComplete="email"
+										placeholder="you@example.com"
+										disabled={actionsDisabled}
+										mix={css({
+											...inputCss,
+											fontSize: typography.fontSize.base,
+											fontFamily: typography.fontFamily,
+										})}
+									/>
+								</label>
+								<label mix={css({ display: 'grid', gap: spacing.xs })}>
+									<span
+										mix={css({
+											color: colors.text,
+											fontWeight: typography.fontWeight.medium,
+											fontSize: typography.fontSize.sm,
+										})}
+									>
+										Password
+									</span>
+									<input
+										type="password"
+										name="password"
+										required
+										autoComplete="current-password"
+										placeholder="Enter your password"
+										disabled={actionsDisabled}
+										mix={css({
+											...inputCss,
+											fontSize: typography.fontSize.base,
+											fontFamily: typography.fontFamily,
+										})}
+									/>
+								</label>
+							</>
+						) : null}
+						<div
+							mix={css({ display: 'flex', gap: spacing.sm, flexWrap: 'wrap' })}
 						>
-							{authorizeLabel}
-						</button>
-						<button
-							type="button"
-							disabled={actionsDisabled}
-							mix={[
-								css({
+							<button
+								type="submit"
+								disabled={actionsDisabled}
+								mix={css({
 									...buttonCss,
 									padding: `${spacing.sm} ${spacing.lg}`,
 									borderRadius: radius.full,
-									border: `2px solid ${colors.border}`,
-									backgroundColor: colors.surface,
-									color: colors.text,
 									fontSize: typography.fontSize.base,
 									cursor: actionsDisabled ? 'not-allowed' : 'pointer',
 									opacity: actionsDisabled ? 0.7 : 1,
-									boxShadow: `0 4px 0 0 ${colors.border}`,
-									'&:active': actionsDisabled
-										? undefined
-										: {
-												transform: 'translateY(4px)',
-												boxShadow: `0 0 0 0 ${colors.border}`,
-											},
-								}),
-								on<HTMLElement, 'click'>('click', () => submitDecision('deny')),
-							]}
-						>
-							Deny
-						</button>
-					</div>
-				</form>
+								})}
+							>
+								{authorizeLabel}
+							</button>
+							<button
+								type="button"
+								disabled={actionsDisabled}
+								mix={[
+									css({
+										...buttonCss,
+										padding: `${spacing.sm} ${spacing.lg}`,
+										borderRadius: radius.full,
+										border: `2px solid ${colors.border}`,
+										backgroundColor: colors.surface,
+										color: colors.text,
+										fontSize: typography.fontSize.base,
+										cursor: actionsDisabled ? 'not-allowed' : 'pointer',
+										opacity: actionsDisabled ? 0.7 : 1,
+										boxShadow: `0 4px 0 0 ${colors.border}`,
+										'&:active': actionsDisabled
+											? undefined
+											: {
+													transform: 'translateY(4px)',
+													boxShadow: `0 0 0 0 ${colors.border}`,
+												},
+									}),
+									on<HTMLElement, 'click'>('click', () =>
+										submitDecision('deny'),
+									),
+								]}
+							>
+								Deny
+							</button>
+						</div>
+					</form>
+				) : null}
 				<a
 					href="/"
 					mix={css({

--- a/client/routes/oauth-callback.tsx
+++ b/client/routes/oauth-callback.tsx
@@ -1,12 +1,10 @@
-import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
 import { css, type Handle } from 'remix/ui'
+import { readRouterSearch } from '#client/router-location.tsx'
+import { colors, radius, spacing, typography } from '#client/styles/tokens.ts'
 
-export function OAuthCallbackRoute(_handle: Handle) {
+export function OAuthCallbackRoute(handle: Handle) {
 	return () => {
-		const params =
-			typeof window === 'undefined'
-				? new URLSearchParams()
-				: new URLSearchParams(window.location.search)
+		const params = new URLSearchParams(readRouterSearch(handle))
 		const error = params.get('error')
 		const description = params.get('error_description')
 		const code = params.get('code')

--- a/client/routes/settings.tsx
+++ b/client/routes/settings.tsx
@@ -1,5 +1,10 @@
 import { css, on, type Handle } from 'remix/ui'
 import {
+	tryConsumeRouteLoaderData,
+	type ClientRouteLoader,
+} from '#client/route-loader-data.tsx'
+import { readRouterUrl } from '#client/router-location.tsx'
+import {
 	archiveAccount,
 	archiveKid,
 	createAccount,
@@ -175,9 +180,14 @@ type SettingsState =
 			quickAmounts: Array<number>
 	  }
 
+export const loader: ClientRouteLoader = async () => {
+	return { settings: await fetchSettings() }
+}
+
 export function SettingsRoute(handle: Handle) {
 	let state: SettingsState = { status: 'loading', message: '', kids: [] }
 	let isRefreshing = false
+	let settingsRefreshInFlight = false
 	let isReordering = false
 	let newKidName = ''
 	let newKidEmoji: string = getRandomDefaultKidEmoji()
@@ -211,7 +221,29 @@ export function SettingsRoute(handle: Handle) {
 		closeTransactionModalCssTimeoutId = null
 	}
 
+	function applySettingsPayload(
+		payload: Awaited<ReturnType<typeof fetchSettings>>,
+	) {
+		state = {
+			status: 'ready',
+			message: '',
+			kids: payload.settings.kids.filter((kid) => !kid.isArchived),
+			archived: payload.settings.archived,
+			quickAmounts: payload.settings.quickAmounts,
+		}
+	}
+
+	function applyRouteLoaderData(currentHref: string) {
+		const payload = tryConsumeRouteLoaderData(handle, 'settings', currentHref)
+		if (!payload) return false
+		applySettingsPayload(payload)
+		isRefreshing = false
+		return true
+	}
+
 	async function refreshSettings() {
+		if (settingsRefreshInFlight) return
+		settingsRefreshInFlight = true
 		const hadReadyData = state.status === 'ready'
 		isRefreshing = hadReadyData
 		if (!hadReadyData) {
@@ -220,13 +252,7 @@ export function SettingsRoute(handle: Handle) {
 		handle.update()
 		try {
 			const payload = await fetchSettings()
-			state = {
-				status: 'ready',
-				message: '',
-				kids: payload.settings.kids.filter((kid) => !kid.isArchived),
-				archived: payload.settings.archived,
-				quickAmounts: payload.settings.quickAmounts,
-			}
+			applySettingsPayload(payload)
 		} catch (error) {
 			const errorMessage =
 				error instanceof Error ? error.message : 'Failed to load settings.'
@@ -240,13 +266,11 @@ export function SettingsRoute(handle: Handle) {
 				}
 			}
 		}
+		settingsRefreshInFlight = false
 		isRefreshing = false
 		handle.update()
 	}
 
-	handle.queueTask(async () => {
-		await refreshSettings()
-	})
 	handle.queueTask(() => {
 		return () => {
 			clearCloseTransactionModalCssTimeout()
@@ -594,1233 +618,1268 @@ export function SettingsRoute(handle: Handle) {
 		}
 	}
 
-	return () => (
-		<section mix={css({ display: 'grid', gap: spacing.lg })}>
-			<header mix={css({ display: 'grid', gap: spacing.xs })}>
-				<h1 mix={css({ margin: 0, color: colors.text })}>Household Settings</h1>
-				<p mix={css({ margin: 0, color: colors.textMuted })}>
-					Manage kids and accounts. Use arrow buttons to reorder.
-				</p>
-			</header>
+	return () => {
+		const currentHref = readRouterUrl(handle)
+		const appliedRouteData = applyRouteLoaderData(currentHref)
+		if (
+			typeof window !== 'undefined' &&
+			state.status === 'loading' &&
+			!appliedRouteData &&
+			!settingsRefreshInFlight
+		) {
+			handle.queueTask(refreshSettings)
+		}
 
-			{state.status === 'loading' ? (
-				<p mix={css({ color: colors.textMuted })}>Loading settings...</p>
-			) : null}
-			{state.status === 'error' ? (
-				<p mix={css({ color: colors.error })}>{state.message}</p>
-			) : null}
-			{isRefreshing ? (
-				<p mix={css({ margin: 0, color: colors.textMuted })}>
-					Saving changes...
-				</p>
-			) : null}
+		return (
+			<section mix={css({ display: 'grid', gap: spacing.lg })}>
+				<header mix={css({ display: 'grid', gap: spacing.xs })}>
+					<h1 mix={css({ margin: 0, color: colors.text })}>
+						Household Settings
+					</h1>
+					<p mix={css({ margin: 0, color: colors.textMuted })}>
+						Manage kids and accounts. Use arrow buttons to reorder.
+					</p>
+				</header>
 
-			{state.status === 'ready' ? (
-				<>
-					<section
-						mix={css({
-							display: 'grid',
-							gap: spacing.sm,
-							padding: spacing.md,
-							border: `3px solid ${colors.border}`,
-							borderRadius: radius.xl,
-							backgroundColor: colors.surface,
-							boxShadow: shadows.md,
-						})}
-					>
-						<h2 mix={css({ margin: 0, color: colors.text })}>Add kid</h2>
-						<div
+				{state.status === 'loading' ? (
+					<p mix={css({ color: colors.textMuted })}>Loading settings...</p>
+				) : null}
+				{state.status === 'error' ? (
+					<p mix={css({ color: colors.error })}>{state.message}</p>
+				) : null}
+				{isRefreshing ? (
+					<p mix={css({ margin: 0, color: colors.textMuted })}>
+						Saving changes...
+					</p>
+				) : null}
+
+				{state.status === 'ready' ? (
+					<>
+						<section
 							mix={css({
 								display: 'grid',
-								gridTemplateColumns: '4rem 1fr auto',
 								gap: spacing.sm,
-								[mq.mobile]: {
-									gridTemplateColumns: '4rem 1fr',
-									'& > button': {
-										gridColumn: '1 / -1',
-									},
-								},
+								padding: spacing.md,
+								border: `3px solid ${colors.border}`,
+								borderRadius: radius.xl,
+								backgroundColor: colors.surface,
+								boxShadow: shadows.md,
 							})}
 						>
-							<input
-								value={newKidEmoji}
-								mix={[
-									css({
-										...inputCss,
-										fontSize: typography.fontSize.xl,
-										fontWeight: typography.fontWeight.bold,
-										textAlign: 'center',
-									}),
-									on<HTMLElement, 'input'>('input', (event) => {
-										if (!(event.currentTarget instanceof HTMLInputElement))
-											return
-										newKidEmoji = normalizeKidEmoji(event.currentTarget.value)
-										handle.update()
-									}),
-								]}
-								aria-label="Kid emoji"
-							/>
-							<input
-								value={newKidName}
-								mix={[
-									css({
-										...inputCss,
-										fontSize: typography.fontSize.xl,
-										fontWeight: typography.fontWeight.bold,
-									}),
-									on<HTMLElement, 'input'>('input', (event) => {
-										if (!(event.currentTarget instanceof HTMLInputElement))
-											return
-										newKidName = event.currentTarget.value
-										handle.update()
-									}),
-								]}
-								placeholder="Kid name"
-							/>
-							<button
-								type="button"
-								mix={[
-									css(buttonCss),
-									on<HTMLElement, 'click'>(
-										'click',
-										() => void handleCreateKid(),
-									),
-								]}
-							>
-								Add
-							</button>
-						</div>
-					</section>
-
-					<section mix={css({ display: 'grid', gap: spacing.md })}>
-						{state.kids.map((kid, kidIndex) => (
-							<article
-								key={kid.id}
+							<h2 mix={css({ margin: 0, color: colors.text })}>Add kid</h2>
+							<div
 								mix={css({
 									display: 'grid',
+									gridTemplateColumns: '4rem 1fr auto',
 									gap: spacing.sm,
-									padding: spacing.lg,
-									border: `3px solid ${colors.border}`,
-									borderRadius: radius.xl,
-									backgroundColor: colors.surface,
-									boxShadow: shadows.md,
+									[mq.mobile]: {
+										gridTemplateColumns: '4rem 1fr',
+										'& > button': {
+											gridColumn: '1 / -1',
+										},
+									},
 								})}
 							>
-								<header
+								<input
+									value={newKidEmoji}
+									mix={[
+										css({
+											...inputCss,
+											fontSize: typography.fontSize.xl,
+											fontWeight: typography.fontWeight.bold,
+											textAlign: 'center',
+										}),
+										on<HTMLElement, 'input'>('input', (event) => {
+											if (!(event.currentTarget instanceof HTMLInputElement))
+												return
+											newKidEmoji = normalizeKidEmoji(event.currentTarget.value)
+											handle.update()
+										}),
+									]}
+									aria-label="Kid emoji"
+								/>
+								<input
+									value={newKidName}
+									mix={[
+										css({
+											...inputCss,
+											fontSize: typography.fontSize.xl,
+											fontWeight: typography.fontWeight.bold,
+										}),
+										on<HTMLElement, 'input'>('input', (event) => {
+											if (!(event.currentTarget instanceof HTMLInputElement))
+												return
+											newKidName = event.currentTarget.value
+											handle.update()
+										}),
+									]}
+									placeholder="Kid name"
+								/>
+								<button
+									type="button"
+									mix={[
+										css(buttonCss),
+										on<HTMLElement, 'click'>(
+											'click',
+											() => void handleCreateKid(),
+										),
+									]}
+								>
+									Add
+								</button>
+							</div>
+						</section>
+
+						<section mix={css({ display: 'grid', gap: spacing.md })}>
+							{state.kids.map((kid, kidIndex) => (
+								<article
+									key={kid.id}
 									mix={css({
 										display: 'grid',
-										gridTemplateColumns: 'auto 4rem 1fr auto',
 										gap: spacing.sm,
-										alignItems: 'center',
-										[mq.mobile]: {
-											gridTemplateColumns: 'auto 4rem 1fr auto',
-											'& [data-kid-actions]': {
-												gridColumn: '1 / -1',
-											},
-										},
+										padding: spacing.lg,
+										border: `3px solid ${colors.border}`,
+										borderRadius: radius.xl,
+										backgroundColor: colors.surface,
+										boxShadow: shadows.md,
 									})}
 								>
-									<div mix={css(reorderControlsCss)}>
-										<button
-											type="button"
-											data-reorder-scope="kid"
-											data-reorder-kid-id={kid.id}
-											data-reorder-direction="up"
-											aria-label={`Move ${kid.name} up`}
-											disabled={kidIndex === 0 || isReordering}
-											mix={[
-												css(reorderButtonCss),
-												on<HTMLElement, 'click'>(
-													'click',
-													() => void handleKidMove(kid.id, -1),
-												),
-											]}
-										>
-											↑
-										</button>
-										<button
-											type="button"
-											data-reorder-scope="kid"
-											data-reorder-kid-id={kid.id}
-											data-reorder-direction="down"
-											aria-label={`Move ${kid.name} down`}
-											disabled={
-												kidIndex === state.kids.length - 1 || isReordering
-											}
-											mix={[
-												css(reorderButtonCss),
-												on<HTMLElement, 'click'>(
-													'click',
-													() => void handleKidMove(kid.id, 1),
-												),
-											]}
-										>
-											↓
-										</button>
-									</div>
-									<input
-										defaultValue={kid.emoji}
-										aria-label={`${kid.name} emoji`}
-										data-kid-emoji={kid.id}
-										mix={[
-											css({
-												...inputCss,
-												fontSize: typography.fontSize.xl,
-												fontWeight: typography.fontWeight.bold,
-												textAlign: 'center',
-											}),
-											on<HTMLElement, 'input'>('input', (event) => {
-												const input = event.currentTarget as HTMLInputElement
-												input.value = normalizeKidEmoji(input.value)
-											}),
-											on<HTMLElement, 'blur'>('blur', async (e) => {
-												const input = e.currentTarget as HTMLInputElement
-												const emoji = normalizeKidEmoji(input.value)
-												input.value = emoji
-												const nameInput = document.querySelector(
-													`input[data-kid-name="${kid.id}"]`,
-												) as HTMLInputElement
-												const name = nameInput?.value || kid.name
-												if (name === kid.name && emoji === kid.emoji) {
-													return
-												}
-												await updateKid({
-													kidId: kid.id,
-													name,
-													emoji,
-												})
-												await refreshSettings()
-											}),
-										]}
-									/>
-									<input
-										defaultValue={kid.name}
-										aria-label={`${kid.name} name`}
-										data-kid-name={kid.id}
-										mix={[
-											css({
-												...inputCss,
-												fontSize: typography.fontSize.xl,
-												fontWeight: typography.fontWeight.bold,
-											}),
-											on<HTMLElement, 'blur'>('blur', async (e) => {
-												const name =
-													(e.currentTarget as HTMLInputElement).value ||
-													kid.name
-												const emojiInput = document.querySelector(
-													`input[data-kid-emoji="${kid.id}"]`,
-												) as HTMLInputElement
-												const emoji = emojiInput?.value || kid.emoji
-												if (name === kid.name && emoji === kid.emoji) {
-													return
-												}
-												await updateKid({
-													kidId: kid.id,
-													name,
-													emoji,
-												})
-												await refreshSettings()
-											}),
-										]}
-									/>
-									<div
-										data-kid-actions
+									<header
 										mix={css({
-											display: 'flex',
-											gap: spacing.xs,
-											flexWrap: 'wrap',
-											justifyContent: 'flex-end',
+											display: 'grid',
+											gridTemplateColumns: 'auto 4rem 1fr auto',
+											gap: spacing.sm,
+											alignItems: 'center',
+											[mq.mobile]: {
+												gridTemplateColumns: 'auto 4rem 1fr auto',
+												'& [data-kid-actions]': {
+													gridColumn: '1 / -1',
+												},
+											},
 										})}
 									>
-										<button
-											type="button"
-											aria-label={`Customize ${kid.name}'s transaction modal`}
-											title="Customize transaction modal"
+										<div mix={css(reorderControlsCss)}>
+											<button
+												type="button"
+												data-reorder-scope="kid"
+												data-reorder-kid-id={kid.id}
+												data-reorder-direction="up"
+												aria-label={`Move ${kid.name} up`}
+												disabled={kidIndex === 0 || isReordering}
+												mix={[
+													css(reorderButtonCss),
+													on<HTMLElement, 'click'>(
+														'click',
+														() => void handleKidMove(kid.id, -1),
+													),
+												]}
+											>
+												↑
+											</button>
+											<button
+												type="button"
+												data-reorder-scope="kid"
+												data-reorder-kid-id={kid.id}
+												data-reorder-direction="down"
+												aria-label={`Move ${kid.name} down`}
+												disabled={
+													kidIndex === state.kids.length - 1 || isReordering
+												}
+												mix={[
+													css(reorderButtonCss),
+													on<HTMLElement, 'click'>(
+														'click',
+														() => void handleKidMove(kid.id, 1),
+													),
+												]}
+											>
+												↓
+											</button>
+										</div>
+										<input
+											defaultValue={kid.emoji}
+											aria-label={`${kid.name} emoji`}
+											data-kid-emoji={kid.id}
 											mix={[
-												css(transactionModalIconButtonCss),
-												on<HTMLElement, 'click'>('click', () => {
-													openTransactionModalCssEditor(kid)
+												css({
+													...inputCss,
+													fontSize: typography.fontSize.xl,
+													fontWeight: typography.fontWeight.bold,
+													textAlign: 'center',
 												}),
-											]}
-										>
-											<SettingsIcon />
-										</button>
-										<button
-											type="button"
-											aria-label={`Archive ${kid.name}`}
-											mix={[
-												css(archiveIconButtonCss),
-												on<HTMLElement, 'click'>('click', async () => {
-													await archiveKid(kid.id)
+												on<HTMLElement, 'input'>('input', (event) => {
+													const input = event.currentTarget as HTMLInputElement
+													input.value = normalizeKidEmoji(input.value)
+												}),
+												on<HTMLElement, 'blur'>('blur', async (e) => {
+													const input = e.currentTarget as HTMLInputElement
+													const emoji = normalizeKidEmoji(input.value)
+													input.value = emoji
+													const nameInput = document.querySelector(
+														`input[data-kid-name="${kid.id}"]`,
+													) as HTMLInputElement
+													const name = nameInput?.value || kid.name
+													if (name === kid.name && emoji === kid.emoji) {
+														return
+													}
+													await updateKid({
+														kidId: kid.id,
+														name,
+														emoji,
+													})
 													await refreshSettings()
 												}),
 											]}
+										/>
+										<input
+											defaultValue={kid.name}
+											aria-label={`${kid.name} name`}
+											data-kid-name={kid.id}
+											mix={[
+												css({
+													...inputCss,
+													fontSize: typography.fontSize.xl,
+													fontWeight: typography.fontWeight.bold,
+												}),
+												on<HTMLElement, 'blur'>('blur', async (e) => {
+													const name =
+														(e.currentTarget as HTMLInputElement).value ||
+														kid.name
+													const emojiInput = document.querySelector(
+														`input[data-kid-emoji="${kid.id}"]`,
+													) as HTMLInputElement
+													const emoji = emojiInput?.value || kid.emoji
+													if (name === kid.name && emoji === kid.emoji) {
+														return
+													}
+													await updateKid({
+														kidId: kid.id,
+														name,
+														emoji,
+													})
+													await refreshSettings()
+												}),
+											]}
+										/>
+										<div
+											data-kid-actions
+											mix={css({
+												display: 'flex',
+												gap: spacing.xs,
+												flexWrap: 'wrap',
+												justifyContent: 'flex-end',
+											})}
 										>
-											<TrashIcon />
-										</button>
-									</div>
-								</header>
-								<p mix={css({ margin: 0, color: colors.textMuted })}>
-									Total: {formatCents(kid.totalBalanceCents)}
-								</p>
-								<div
-									mix={css({
-										display: 'flex',
-										flexDirection: 'column',
-										backgroundColor: colors.surface,
-										borderRadius: radius.lg,
-										border:
-											kid.accounts.length > 0
-												? `2px solid ${colors.border}`
-												: 'none',
-										overflow: 'hidden',
-									})}
-								>
-									{kid.accounts.map((account, index) => {
-										const textColors = getAccountTextColors(account.colorToken)
-										return (
-											<div
-												key={account.id}
-												mix={css({
-													display: 'grid',
-													gridTemplateColumns: 'auto 1fr auto auto auto',
-													rowGap: spacing.xs,
-													columnGap: spacing.sm,
-													alignItems: 'center',
-													padding: spacing.md,
-													background: getAccountGradientBackground(
-														account.colorToken,
-													),
-													borderBottom:
-														index < kid.accounts.length - 1
-															? `1px solid ${colors.border}`
-															: 'none',
-													[mq.mobile]: {
-														gridTemplateColumns: 'auto 1fr auto auto',
-													},
-												})}
+											<button
+												type="button"
+												aria-label={`Customize ${kid.name}'s transaction modal`}
+												title="Customize transaction modal"
+												mix={[
+													css(transactionModalIconButtonCss),
+													on<HTMLElement, 'click'>('click', () => {
+														openTransactionModalCssEditor(kid)
+													}),
+												]}
 											>
-												<div mix={css(reorderControlsCss)}>
-													<button
-														type="button"
-														data-reorder-scope="account"
-														data-reorder-kid-id={kid.id}
-														data-reorder-account-id={account.id}
-														data-reorder-direction="up"
-														aria-label={`Move ${account.name} up`}
-														disabled={index === 0 || isReordering}
-														mix={[
-															css(reorderButtonCss),
-															on(
-																'click',
-																() =>
-																	void handleAccountMove(
-																		kid.id,
-																		account.id,
-																		-1,
-																	),
-															),
-														]}
-													>
-														↑
-													</button>
-													<button
-														type="button"
-														data-reorder-scope="account"
-														data-reorder-kid-id={kid.id}
-														data-reorder-account-id={account.id}
-														data-reorder-direction="down"
-														aria-label={`Move ${account.name} down`}
-														disabled={
-															index === kid.accounts.length - 1 || isReordering
-														}
-														mix={[
-															css(reorderButtonCss),
-															on(
-																'click',
-																() =>
-																	void handleAccountMove(kid.id, account.id, 1),
-															),
-														]}
-													>
-														↓
-													</button>
-												</div>
+												<SettingsIcon />
+											</button>
+											<button
+												type="button"
+												aria-label={`Archive ${kid.name}`}
+												mix={[
+													css(archiveIconButtonCss),
+													on<HTMLElement, 'click'>('click', async () => {
+														await archiveKid(kid.id)
+														await refreshSettings()
+													}),
+												]}
+											>
+												<TrashIcon />
+											</button>
+										</div>
+									</header>
+									<p mix={css({ margin: 0, color: colors.textMuted })}>
+										Total: {formatCents(kid.totalBalanceCents)}
+									</p>
+									<div
+										mix={css({
+											display: 'flex',
+											flexDirection: 'column',
+											backgroundColor: colors.surface,
+											borderRadius: radius.lg,
+											border:
+												kid.accounts.length > 0
+													? `2px solid ${colors.border}`
+													: 'none',
+											overflow: 'hidden',
+										})}
+									>
+										{kid.accounts.map((account, index) => {
+											const textColors = getAccountTextColors(
+												account.colorToken,
+											)
+											return (
 												<div
+													key={account.id}
 													mix={css({
 														display: 'grid',
-														gap: 2,
+														gridTemplateColumns: 'auto 1fr auto auto auto',
+														rowGap: spacing.xs,
+														columnGap: spacing.sm,
+														alignItems: 'center',
+														padding: spacing.md,
+														background: getAccountGradientBackground(
+															account.colorToken,
+														),
+														borderBottom:
+															index < kid.accounts.length - 1
+																? `1px solid ${colors.border}`
+																: 'none',
 														[mq.mobile]: {
-															gridColumn: '2 / -1',
-															gridRow: '1',
+															gridTemplateColumns: 'auto 1fr auto auto',
 														},
 													})}
 												>
-													<input
-														defaultValue={account.name}
-														aria-label={`${account.name} name`}
-														data-account-name={account.id}
-														mix={[
-															css({
-																...inputCss,
-																backgroundColor: 'transparent',
-																border: '2px solid transparent',
-																boxShadow: 'none',
-																fontWeight: 'bold',
-																color: textColors.text,
-																padding: spacing.xs,
-																'&:focus': {
-																	...inputCss['&:focus'],
-																	backgroundColor: colors.surface,
-																	color: colors.text,
-																},
-															}),
-															on<HTMLElement, 'blur'>(
-																'blur',
-																() => void saveAccountDraft(account),
-															),
-														]}
-													/>
-													<span
+													<div mix={css(reorderControlsCss)}>
+														<button
+															type="button"
+															data-reorder-scope="account"
+															data-reorder-kid-id={kid.id}
+															data-reorder-account-id={account.id}
+															data-reorder-direction="up"
+															aria-label={`Move ${account.name} up`}
+															disabled={index === 0 || isReordering}
+															mix={[
+																css(reorderButtonCss),
+																on(
+																	'click',
+																	() =>
+																		void handleAccountMove(
+																			kid.id,
+																			account.id,
+																			-1,
+																		),
+																),
+															]}
+														>
+															↑
+														</button>
+														<button
+															type="button"
+															data-reorder-scope="account"
+															data-reorder-kid-id={kid.id}
+															data-reorder-account-id={account.id}
+															data-reorder-direction="down"
+															aria-label={`Move ${account.name} down`}
+															disabled={
+																index === kid.accounts.length - 1 ||
+																isReordering
+															}
+															mix={[
+																css(reorderButtonCss),
+																on(
+																	'click',
+																	() =>
+																		void handleAccountMove(
+																			kid.id,
+																			account.id,
+																			1,
+																		),
+																),
+															]}
+														>
+															↓
+														</button>
+													</div>
+													<div
 														mix={css({
-															color: textColors.muted,
-															fontSize: typography.fontSize.sm,
+															display: 'grid',
+															gap: 2,
+															[mq.mobile]: {
+																gridColumn: '2 / -1',
+																gridRow: '1',
+															},
 														})}
 													>
-														{formatCents(account.balanceCents)} ·{' '}
-														{formatApyLabel(account.apyBasisPoints)}
-													</span>
-												</div>
-												<label
-													mix={css({
-														display: 'grid',
-														gap: 2,
-														color: textColors.muted,
-														fontSize: typography.fontSize.sm,
-														[mq.mobile]: {
-															gridColumn: '2 / 4',
-															gridRow: '3',
-														},
-													})}
-												>
-													<span>APY</span>
-													<input
-														type="number"
-														min="0"
-														step="0.01"
-														aria-label={`${account.name} APY percent`}
-														data-account-apy={account.id}
-														defaultValue={formatApyPercentInputValue(
-															account.apyBasisPoints,
-														)}
+														<input
+															defaultValue={account.name}
+															aria-label={`${account.name} name`}
+															data-account-name={account.id}
+															mix={[
+																css({
+																	...inputCss,
+																	backgroundColor: 'transparent',
+																	border: '2px solid transparent',
+																	boxShadow: 'none',
+																	fontWeight: 'bold',
+																	color: textColors.text,
+																	padding: spacing.xs,
+																	'&:focus': {
+																		...inputCss['&:focus'],
+																		backgroundColor: colors.surface,
+																		color: colors.text,
+																	},
+																}),
+																on<HTMLElement, 'blur'>(
+																	'blur',
+																	() => void saveAccountDraft(account),
+																),
+															]}
+														/>
+														<span
+															mix={css({
+																color: textColors.muted,
+																fontSize: typography.fontSize.sm,
+															})}
+														>
+															{formatCents(account.balanceCents)} ·{' '}
+															{formatApyLabel(account.apyBasisPoints)}
+														</span>
+													</div>
+													<label
+														mix={css({
+															display: 'grid',
+															gap: 2,
+															color: textColors.muted,
+															fontSize: typography.fontSize.sm,
+															[mq.mobile]: {
+																gridColumn: '2 / 4',
+																gridRow: '3',
+															},
+														})}
+													>
+														<span>APY</span>
+														<input
+															type="number"
+															min="0"
+															step="0.01"
+															aria-label={`${account.name} APY percent`}
+															data-account-apy={account.id}
+															defaultValue={formatApyPercentInputValue(
+																account.apyBasisPoints,
+															)}
+															mix={[
+																css({
+																	...inputCss,
+																	backgroundColor: colors.surface,
+																	color: colors.text,
+																	colorScheme: 'light dark',
+																}),
+																on<HTMLElement, 'blur'>(
+																	'blur',
+																	() => void saveAccountDraft(account),
+																),
+															]}
+														/>
+													</label>
+													<select
+														aria-label={`${account.name} color`}
+														data-account-color={account.id}
 														mix={[
 															css({
 																...inputCss,
 																backgroundColor: colors.surface,
 																color: colors.text,
 																colorScheme: 'light dark',
+																[mq.mobile]: {
+																	gridColumn: '2 / 4',
+																	gridRow: '2',
+																},
 															}),
-															on<HTMLElement, 'blur'>(
-																'blur',
+															on<HTMLElement, 'change'>(
+																'change',
 																() => void saveAccountDraft(account),
 															),
 														]}
-													/>
-												</label>
-												<select
-													aria-label={`${account.name} color`}
-													data-account-color={account.id}
-													mix={[
-														css({
-															...inputCss,
-															backgroundColor: colors.surface,
-															color: colors.text,
-															colorScheme: 'light dark',
-															[mq.mobile]: {
-																gridColumn: '2 / 4',
-																gridRow: '2',
-															},
-														}),
-														on<HTMLElement, 'change'>(
-															'change',
-															() => void saveAccountDraft(account),
-														),
-													]}
-												>
-													{accountColorTokens.map((color) => (
-														<option
-															key={color}
-															value={color}
-															selected={account.colorToken === color}
-														>
-															{color}
-														</option>
-													))}
-												</select>
-												<button
-													type="button"
-													aria-label={`Archive ${account.name}`}
-													mix={[
-														css({
-															...archiveIconButtonCss,
-															[mq.mobile]: {
-																gridColumn: '4',
-																gridRow: '2',
-																justifySelf: 'end',
-															},
-														}),
-														on<HTMLElement, 'click'>('click', async () => {
-															await archiveAccount(account.id)
-															await refreshSettings()
-														}),
-													]}
-												>
-													<TrashIcon />
-												</button>
-											</div>
-										)
-									})}
-								</div>
-								<div
-									mix={css({
-										display: 'grid',
-										gridTemplateColumns: '1fr auto auto auto',
-										gap: spacing.sm,
-										padding: spacing.md,
-										border: `2px dashed ${colors.border}`,
-										borderRadius: radius.lg,
-										background: getAccountGradientBackground(
-											getCreateAccountColor(kid.id),
-										),
-										[mq.mobile]: {
-											gridTemplateColumns: '1fr',
-										},
-									})}
-								>
-									<input
-										data-create-account-name={kid.id}
-										placeholder="New account name"
-										mix={css(inputCss)}
-									/>
-									<label
+													>
+														{accountColorTokens.map((color) => (
+															<option
+																key={color}
+																value={color}
+																selected={account.colorToken === color}
+															>
+																{color}
+															</option>
+														))}
+													</select>
+													<button
+														type="button"
+														aria-label={`Archive ${account.name}`}
+														mix={[
+															css({
+																...archiveIconButtonCss,
+																[mq.mobile]: {
+																	gridColumn: '4',
+																	gridRow: '2',
+																	justifySelf: 'end',
+																},
+															}),
+															on<HTMLElement, 'click'>('click', async () => {
+																await archiveAccount(account.id)
+																await refreshSettings()
+															}),
+														]}
+													>
+														<TrashIcon />
+													</button>
+												</div>
+											)
+										})}
+									</div>
+									<div
 										mix={css({
 											display: 'grid',
-											gap: spacing.xs,
-											color: colors.text,
-											fontSize: typography.fontSize.sm,
+											gridTemplateColumns: '1fr auto auto auto',
+											gap: spacing.sm,
+											padding: spacing.md,
+											border: `2px dashed ${colors.border}`,
+											borderRadius: radius.lg,
+											background: getAccountGradientBackground(
+												getCreateAccountColor(kid.id),
+											),
+											[mq.mobile]: {
+												gridTemplateColumns: '1fr',
+											},
 										})}
 									>
-										<span>APY</span>
 										<input
-											type="number"
-											min="0"
-											step="0.01"
-											aria-label="New account APY percent"
-											data-create-account-apy={kid.id}
-											value={getCreateAccountApyDraft(kid.id)}
+											data-create-account-name={kid.id}
+											placeholder="New account name"
+											mix={css(inputCss)}
+										/>
+										<label
+											mix={css({
+												display: 'grid',
+												gap: spacing.xs,
+												color: colors.text,
+												fontSize: typography.fontSize.sm,
+											})}
+										>
+											<span>APY</span>
+											<input
+												type="number"
+												min="0"
+												step="0.01"
+												aria-label="New account APY percent"
+												data-create-account-apy={kid.id}
+												value={getCreateAccountApyDraft(kid.id)}
+												mix={[
+													css(inputCss),
+													on<HTMLElement, 'input'>('input', (event) => {
+														if (
+															!(event.currentTarget instanceof HTMLInputElement)
+														)
+															return
+														newAccountApyDraftByKidId[kid.id] =
+															event.currentTarget.value
+														const apyBasisPoints = parseApyPercentToBasisPoints(
+															event.currentTarget.value,
+														)
+														if (apyBasisPoints !== null) {
+															event.currentTarget.setCustomValidity('')
+															newAccountApyBasisPointsByKidId[kid.id] =
+																apyBasisPoints
+														}
+														handle.update()
+													}),
+												]}
+											/>
+										</label>
+										<select
+											data-create-account-color={kid.id}
+											value={getCreateAccountColor(kid.id)}
 											mix={[
 												css(inputCss),
-												on<HTMLElement, 'input'>('input', (event) => {
+												on<HTMLElement, 'change'>('change', (event) => {
 													if (
-														!(event.currentTarget instanceof HTMLInputElement)
+														!(event.currentTarget instanceof HTMLSelectElement)
 													)
 														return
-													newAccountApyDraftByKidId[kid.id] =
+													newAccountColorsByKidId[kid.id] =
 														event.currentTarget.value
-													const apyBasisPoints = parseApyPercentToBasisPoints(
-														event.currentTarget.value,
-													)
-													if (apyBasisPoints !== null) {
-														event.currentTarget.setCustomValidity('')
-														newAccountApyBasisPointsByKidId[kid.id] =
-															apyBasisPoints
-													}
 													handle.update()
 												}),
 											]}
-										/>
-									</label>
-									<select
-										data-create-account-color={kid.id}
-										value={getCreateAccountColor(kid.id)}
-										mix={[
-											css(inputCss),
-											on<HTMLElement, 'change'>('change', (event) => {
-												if (!(event.currentTarget instanceof HTMLSelectElement))
-													return
-												newAccountColorsByKidId[kid.id] =
-													event.currentTarget.value
-												handle.update()
-											}),
-										]}
-									>
-										{accountColorTokens.map((color) => (
-											<option key={color} value={color}>
-												{color}
-											</option>
-										))}
-									</select>
-									<button
-										type="button"
-										mix={[
-											css(buttonCss),
-											on<HTMLElement, 'click'>('click', async () => {
-												const nameInput = document.querySelector(
-													`input[data-create-account-name="${kid.id}"]`,
-												)
-												const colorSelect = document.querySelector(
-													`select[data-create-account-color="${kid.id}"]`,
-												)
-												const apyInput = document.querySelector(
-													`input[data-create-account-apy="${kid.id}"]`,
-												)
-												if (
-													!(nameInput instanceof HTMLInputElement) ||
-													!(colorSelect instanceof HTMLSelectElement) ||
-													!(apyInput instanceof HTMLInputElement)
-												) {
-													return
-												}
-												const accountName = nameInput.value.trim()
-												if (!accountName) return
-												const apyBasisPoints = parseApyPercentToBasisPoints(
-													apyInput.value,
-												)
-												if (apyBasisPoints === null) {
-													apyInput.setCustomValidity(
-														'Enter a valid APY percent between 0 and 1000.',
-													)
-													apyInput.reportValidity()
-													notify(
-														'Enter a valid APY percent between 0 and 1000.',
-													)
-													return
-												}
-												apyInput.setCustomValidity('')
-												await createAccount({
-													kidId: kid.id,
-													name: accountName,
-													apyBasisPoints,
-													colorToken: getCreateAccountColor(kid.id),
-												})
-												newAccountApyDraftByKidId[kid.id] =
-													formatApyPercentInputValue(0)
-												nameInput.value = ''
-												await refreshSettings()
-											}),
-										]}
-									>
-										Add account
-									</button>
-								</div>
-							</article>
-						))}
-					</section>
-
-					<section
-						mix={css({
-							display: 'grid',
-							gap: spacing.sm,
-							padding: spacing.md,
-							border: `3px solid ${colors.border}`,
-							borderRadius: radius.xl,
-							backgroundColor: colors.surface,
-							boxShadow: shadows.md,
-						})}
-					>
-						<h2 mix={css({ margin: 0, color: colors.text })}>Quick amounts</h2>
-
-						<div
-							mix={css({ display: 'flex', flexWrap: 'wrap', gap: spacing.sm })}
-						>
-							{state.quickAmounts.map((amount) => (
-								<div
-									key={amount}
-									mix={css({
-										display: 'flex',
-										alignItems: 'center',
-										gap: spacing.xs,
-										padding: `${spacing.xs} ${spacing.sm}`,
-										backgroundColor: colors.primarySoft,
-										borderRadius: radius.full,
-										border: `2px solid ${colors.primarySoftStrong}`,
-										fontWeight: typography.fontWeight.bold,
-									})}
-								>
-									<span>{formatCents(amount)}</span>
-									<button
-										type="button"
-										mix={[
-											css({
-												background: 'none',
-												border: 'none',
-												cursor: 'pointer',
-												color: colors.textMuted,
-												display: 'flex',
-												alignItems: 'center',
-												justifyContent: 'center',
-												padding: 0,
-												fontSize: typography.fontSize.lg,
-												lineHeight: 1,
-												'&:hover': { color: colors.error },
-											}),
-											on<HTMLElement, 'click'>('click', async () => {
-												if (state.status !== 'ready') return
-												const newAmounts = state.quickAmounts.filter(
-													(a) => a !== amount,
-												)
-												await setQuickAmounts(newAmounts)
-												await refreshSettings()
-											}),
-										]}
-										aria-label={`Remove ${formatCents(amount)}`}
-									>
-										×
-									</button>
-								</div>
-							))}
-						</div>
-
-						<form
-							data-router-skip
-							mix={[
-								css({
-									display: 'grid',
-									gridTemplateColumns: '1fr auto',
-									gap: spacing.sm,
-									marginTop: spacing.sm,
-									[mq.mobile]: {
-										gridTemplateColumns: '1fr',
-									},
-								}),
-								on<HTMLElement, 'submit'>('submit', async (event) => {
-									event.preventDefault()
-									if (state.status !== 'ready') return
-									if (!(event.currentTarget instanceof HTMLFormElement)) return
-									const input =
-										event.currentTarget.elements.namedItem('newAmount')
-									if (!(input instanceof HTMLInputElement)) return
-
-									const val = Number(input.value)
-									if (Number.isFinite(val) && val > 0) {
-										const cents = Math.round(val * 100)
-										if (!state.quickAmounts.includes(cents)) {
-											const newAmounts = [...state.quickAmounts, cents].sort(
-												(a, b) => a - b,
-											)
-											await setQuickAmounts(newAmounts)
-											await refreshSettings()
-										}
-										input.value = ''
-									}
-								}),
-							]}
-						>
-							<input
-								name="newAmount"
-								type="number"
-								step="0.01"
-								min="0.01"
-								placeholder="New amount (e.g. 5.00)"
-								mix={css(inputCss)}
-							/>
-							<button type="submit" mix={css(buttonCss)}>
-								Add
-							</button>
-						</form>
-					</section>
-
-					<section
-						mix={css({
-							display: 'grid',
-							gap: spacing.xs,
-							padding: spacing.md,
-							border: `3px solid ${colors.border}`,
-							borderRadius: radius.xl,
-							backgroundColor: colors.surface,
-							boxShadow: shadows.md,
-						})}
-					>
-						<h2 mix={css({ margin: 0, color: colors.text })}>
-							How account APY works
-						</h2>
-						<p mix={css({ margin: 0, color: colors.textMuted })}>
-							APY means annual percentage yield. Set it per account to earn
-							monthly interest automatically: on the first day of each month,
-							Kids Ledger snapshots that account&apos;s balance, converts the
-							APY to a monthly compound rate, and records a Monthly interest
-							transaction when the rounded payout is positive.
-						</p>
-					</section>
-
-					<section
-						mix={css({
-							display: 'grid',
-							gap: spacing.md,
-							padding: spacing.md,
-							border: `3px solid ${colors.error}`,
-							borderRadius: radius.xl,
-							backgroundColor: 'color-mix(in srgb, #dc2626 5%, transparent)',
-							boxShadow: shadows.md,
-						})}
-					>
-						<h2 mix={css({ margin: 0, color: colors.error })}>Danger Zone</h2>
-
-						<div mix={css({ display: 'grid', gap: spacing.sm })}>
-							<h3
-								mix={css({
-									margin: 0,
-									color: colors.text,
-									fontSize: typography.fontSize.lg,
-								})}
-							>
-								Archive management
-							</h3>
-							{state.archived.kids.length === 0 &&
-							state.archived.accounts.length === 0 ? (
-								<div
-									mix={css({
-										display: 'flex',
-										flexDirection: 'column',
-										alignItems: 'center',
-										gap: spacing.sm,
-										padding: spacing.xl,
-										color: colors.textMuted,
-									})}
-								>
-									<span mix={css({ fontSize: '2rem' })}>📭</span>
-									<p mix={css({ margin: 0 })}>No archived records.</p>
-								</div>
-							) : null}
-							{state.archived.kids.map((kid) => (
-								<div key={kid.id} mix={css(archivedRowCss)}>
-									<span>
-										{kid.emoji} {kid.name}
-									</span>
-									<div mix={css(archivedRowActionsCss)}>
+										>
+											{accountColorTokens.map((color) => (
+												<option key={color} value={color}>
+													{color}
+												</option>
+											))}
+										</select>
 										<button
 											type="button"
 											mix={[
 												css(buttonCss),
 												on<HTMLElement, 'click'>('click', async () => {
-													try {
-														await unarchiveKid(kid.id)
-														await refreshSettings()
-													} catch (error) {
-														notify(
-															error instanceof Error
-																? error.message
-																: 'Could not unarchive kid.',
-														)
+													const nameInput = document.querySelector(
+														`input[data-create-account-name="${kid.id}"]`,
+													)
+													const colorSelect = document.querySelector(
+														`select[data-create-account-color="${kid.id}"]`,
+													)
+													const apyInput = document.querySelector(
+														`input[data-create-account-apy="${kid.id}"]`,
+													)
+													if (
+														!(nameInput instanceof HTMLInputElement) ||
+														!(colorSelect instanceof HTMLSelectElement) ||
+														!(apyInput instanceof HTMLInputElement)
+													) {
+														return
 													}
-												}),
-											]}
-										>
-											Unarchive
-										</button>
-										<button
-											type="button"
-											mix={[
-												css(dangerButtonCss),
-												on<HTMLElement, 'click'>('click', async () => {
-													await deleteKid(kid.id)
+													const accountName = nameInput.value.trim()
+													if (!accountName) return
+													const apyBasisPoints = parseApyPercentToBasisPoints(
+														apyInput.value,
+													)
+													if (apyBasisPoints === null) {
+														apyInput.setCustomValidity(
+															'Enter a valid APY percent between 0 and 1000.',
+														)
+														apyInput.reportValidity()
+														notify(
+															'Enter a valid APY percent between 0 and 1000.',
+														)
+														return
+													}
+													apyInput.setCustomValidity('')
+													await createAccount({
+														kidId: kid.id,
+														name: accountName,
+														apyBasisPoints,
+														colorToken: getCreateAccountColor(kid.id),
+													})
+													newAccountApyDraftByKidId[kid.id] =
+														formatApyPercentInputValue(0)
+													nameInput.value = ''
 													await refreshSettings()
 												}),
 											]}
 										>
-											Delete forever
+											Add account
 										</button>
 									</div>
-								</div>
+								</article>
 							))}
-							{state.archived.accounts.map((account) => (
-								<div key={account.id} mix={css(archivedRowCss)}>
-									<span>
-										{account.kidName} · {account.name}
-									</span>
-									<div mix={css(archivedRowActionsCss)}>
-										<button
-											type="button"
-											mix={[
-												css(buttonCss),
-												on<HTMLElement, 'click'>('click', async () => {
-													try {
-														await unarchiveAccount(account.id)
-														await refreshSettings()
-													} catch (error) {
-														notify(
-															error instanceof Error
-																? error.message
-																: 'Could not unarchive account.',
-														)
-													}
-												}),
-											]}
-										>
-											Unarchive
-										</button>
-										<button
-											type="button"
-											mix={[
-												css(dangerButtonCss),
-												on<HTMLElement, 'click'>('click', async () => {
-													await deleteAccount(account.id)
-													await refreshSettings()
-												}),
-											]}
-										>
-											Delete forever
-										</button>
-									</div>
-								</div>
-							))}
-						</div>
+						</section>
 
-						<div
+						<section
 							mix={css({
 								display: 'grid',
 								gap: spacing.sm,
-								paddingTop: spacing.md,
-								borderTop: `1px solid color-mix(in srgb, #dc2626 20%, transparent)`,
+								padding: spacing.md,
+								border: `3px solid ${colors.border}`,
+								borderRadius: radius.xl,
+								backgroundColor: colors.surface,
+								boxShadow: shadows.md,
 							})}
 						>
-							<h3
-								mix={css({
-									margin: 0,
-									color: colors.text,
-									fontSize: typography.fontSize.lg,
-								})}
-							>
-								Data export
-							</h3>
-							<a
-								href="/ledger/export/json"
-								mix={css({
-									color: colors.error,
-									fontWeight: typography.fontWeight.bold,
-								})}
-							>
-								Download JSON backup
-							</a>
-						</div>
-					</section>
+							<h2 mix={css({ margin: 0, color: colors.text })}>
+								Quick amounts
+							</h2>
 
-					{editingKidTransactionModalCss ? (
-						<div
-							mix={[
-								css({
-									position: 'fixed',
-									inset: 0,
-									backgroundColor: 'rgba(0, 0, 0, 0.45)',
-									display: 'grid',
-									placeItems: 'center',
-									padding: spacing.md,
-									zIndex: 1000,
-									pointerEvents: transactionModalCssClosing ? 'none' : 'auto',
-									animation: transactionModalCssClosing
-										? `modal-backdrop-out ${modalCloseAnimationDurationMs}ms ease-in forwards`
-										: 'modal-backdrop-in 180ms ease-out forwards',
-									[mq.mobile]: {
-										padding: 0,
-										placeItems: 'stretch',
-									},
-								}),
-								on<HTMLElement, 'click'>('click', (event) => {
-									if (event.target === event.currentTarget) {
-										closeTransactionModalCssEditor()
-									}
-								}),
-							]}
-						>
-							<section
-								role="dialog"
-								aria-modal="true"
-								aria-labelledby="kid-transaction-modal-css-title"
+							<div
+								mix={css({
+									display: 'flex',
+									flexWrap: 'wrap',
+									gap: spacing.sm,
+								})}
+							>
+								{state.quickAmounts.map((amount) => (
+									<div
+										key={amount}
+										mix={css({
+											display: 'flex',
+											alignItems: 'center',
+											gap: spacing.xs,
+											padding: `${spacing.xs} ${spacing.sm}`,
+											backgroundColor: colors.primarySoft,
+											borderRadius: radius.full,
+											border: `2px solid ${colors.primarySoftStrong}`,
+											fontWeight: typography.fontWeight.bold,
+										})}
+									>
+										<span>{formatCents(amount)}</span>
+										<button
+											type="button"
+											mix={[
+												css({
+													background: 'none',
+													border: 'none',
+													cursor: 'pointer',
+													color: colors.textMuted,
+													display: 'flex',
+													alignItems: 'center',
+													justifyContent: 'center',
+													padding: 0,
+													fontSize: typography.fontSize.lg,
+													lineHeight: 1,
+													'&:hover': { color: colors.error },
+												}),
+												on<HTMLElement, 'click'>('click', async () => {
+													if (state.status !== 'ready') return
+													const newAmounts = state.quickAmounts.filter(
+														(a) => a !== amount,
+													)
+													await setQuickAmounts(newAmounts)
+													await refreshSettings()
+												}),
+											]}
+											aria-label={`Remove ${formatCents(amount)}`}
+										>
+											×
+										</button>
+									</div>
+								))}
+							</div>
+
+							<form
+								data-router-skip
 								mix={[
 									css({
-										width: 'min(42rem, 100%)',
-										maxHeight: '85dvh',
-										overflow: 'auto',
 										display: 'grid',
-										gap: spacing.md,
-										padding: spacing.lg,
-										borderRadius: radius.xl,
-										border: `3px solid ${colors.border}`,
-										backgroundColor: colors.surface,
-										boxShadow: shadows.lg,
-										animation: transactionModalCssClosing
-											? `modal-close ${modalCloseAnimationDurationMs}ms ease-in forwards`
-											: 'modal-pop 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards',
+										gridTemplateColumns: '1fr auto',
+										gap: spacing.sm,
+										marginTop: spacing.sm,
 										[mq.mobile]: {
-											width: '100%',
-											maxHeight: '100dvh',
-											minHeight: '100dvh',
-											borderRadius: 0,
-											border: 'none',
-											gap: spacing.sm,
-											padding: spacing.md,
+											gridTemplateColumns: '1fr',
 										},
 									}),
-									on<HTMLElement, 'keydown'>(
-										'keydown',
-										handleTransactionModalCssKeydown,
-									),
+									on<HTMLElement, 'submit'>('submit', async (event) => {
+										event.preventDefault()
+										if (state.status !== 'ready') return
+										if (!(event.currentTarget instanceof HTMLFormElement))
+											return
+										const input =
+											event.currentTarget.elements.namedItem('newAmount')
+										if (!(input instanceof HTMLInputElement)) return
+
+										const val = Number(input.value)
+										if (Number.isFinite(val) && val > 0) {
+											const cents = Math.round(val * 100)
+											if (!state.quickAmounts.includes(cents)) {
+												const newAmounts = [...state.quickAmounts, cents].sort(
+													(a, b) => a - b,
+												)
+												await setQuickAmounts(newAmounts)
+												await refreshSettings()
+											}
+											input.value = ''
+										}
+									}),
 								]}
 							>
-								<header
+								<input
+									name="newAmount"
+									type="number"
+									step="0.01"
+									min="0.01"
+									placeholder="New amount (e.g. 5.00)"
+									mix={css(inputCss)}
+								/>
+								<button type="submit" mix={css(buttonCss)}>
+									Add
+								</button>
+							</form>
+						</section>
+
+						<section
+							mix={css({
+								display: 'grid',
+								gap: spacing.xs,
+								padding: spacing.md,
+								border: `3px solid ${colors.border}`,
+								borderRadius: radius.xl,
+								backgroundColor: colors.surface,
+								boxShadow: shadows.md,
+							})}
+						>
+							<h2 mix={css({ margin: 0, color: colors.text })}>
+								How account APY works
+							</h2>
+							<p mix={css({ margin: 0, color: colors.textMuted })}>
+								APY means annual percentage yield. Set it per account to earn
+								monthly interest automatically: on the first day of each month,
+								Kids Ledger snapshots that account&apos;s balance, converts the
+								APY to a monthly compound rate, and records a Monthly interest
+								transaction when the rounded payout is positive.
+							</p>
+						</section>
+
+						<section
+							mix={css({
+								display: 'grid',
+								gap: spacing.md,
+								padding: spacing.md,
+								border: `3px solid ${colors.error}`,
+								borderRadius: radius.xl,
+								backgroundColor: 'color-mix(in srgb, #dc2626 5%, transparent)',
+								boxShadow: shadows.md,
+							})}
+						>
+							<h2 mix={css({ margin: 0, color: colors.error })}>Danger Zone</h2>
+
+							<div mix={css({ display: 'grid', gap: spacing.sm })}>
+								<h3
 									mix={css({
-										display: 'flex',
-										justifyContent: 'space-between',
+										margin: 0,
+										color: colors.text,
+										fontSize: typography.fontSize.lg,
 									})}
 								>
-									<div mix={css({ display: 'grid', gap: spacing.xs })}>
-										<h3
-											id="kid-transaction-modal-css-title"
-											mix={css({ margin: 0, color: colors.text })}
-										>
-											Customize {editingKidTransactionModalCss.kidName}&apos;s
-											transaction modal
-										</h3>
-										<p mix={css({ margin: 0, color: colors.textMuted })}>
-											Enter declarations or full CSS rules. When this kid&apos;s
-											transaction modal is open on Home, the styles apply to the
-											whole page.
-										</p>
-									</div>
-									<button
-										type="button"
-										mix={[
-											css(buttonCss),
-											on<HTMLElement, 'click'>(
-												'click',
-												closeTransactionModalCssEditor,
-											),
-										]}
-										disabled={transactionModalCssSaving}
-									>
-										Close
-									</button>
-								</header>
-								<section mix={css({ display: 'grid', gap: spacing.sm })}>
-									<strong mix={css({ color: colors.text })}>
-										Live preview
-									</strong>
-									<p mix={css({ margin: 0, color: colors.textMuted })}>
-										Updates in real time as you type.
-									</p>
-									{transactionModalCssDraft.trim() ? (
-										<style data-kid-transaction-modal-preview-css>
-											{buildTransactionModalCss(transactionModalCssDraft)}
-										</style>
-									) : null}
-									<section
-										data-kid-transaction-modal-preview
+									Archive management
+								</h3>
+								{state.archived.kids.length === 0 &&
+								state.archived.accounts.length === 0 ? (
+									<div
 										mix={css({
-											width: 'min(30rem, 100%)',
+											display: 'flex',
+											flexDirection: 'column',
+											alignItems: 'center',
+											gap: spacing.sm,
+											padding: spacing.xl,
+											color: colors.textMuted,
+										})}
+									>
+										<span mix={css({ fontSize: '2rem' })}>📭</span>
+										<p mix={css({ margin: 0 })}>No archived records.</p>
+									</div>
+								) : null}
+								{state.archived.kids.map((kid) => (
+									<div key={kid.id} mix={css(archivedRowCss)}>
+										<span>
+											{kid.emoji} {kid.name}
+										</span>
+										<div mix={css(archivedRowActionsCss)}>
+											<button
+												type="button"
+												mix={[
+													css(buttonCss),
+													on<HTMLElement, 'click'>('click', async () => {
+														try {
+															await unarchiveKid(kid.id)
+															await refreshSettings()
+														} catch (error) {
+															notify(
+																error instanceof Error
+																	? error.message
+																	: 'Could not unarchive kid.',
+															)
+														}
+													}),
+												]}
+											>
+												Unarchive
+											</button>
+											<button
+												type="button"
+												mix={[
+													css(dangerButtonCss),
+													on<HTMLElement, 'click'>('click', async () => {
+														await deleteKid(kid.id)
+														await refreshSettings()
+													}),
+												]}
+											>
+												Delete forever
+											</button>
+										</div>
+									</div>
+								))}
+								{state.archived.accounts.map((account) => (
+									<div key={account.id} mix={css(archivedRowCss)}>
+										<span>
+											{account.kidName} · {account.name}
+										</span>
+										<div mix={css(archivedRowActionsCss)}>
+											<button
+												type="button"
+												mix={[
+													css(buttonCss),
+													on<HTMLElement, 'click'>('click', async () => {
+														try {
+															await unarchiveAccount(account.id)
+															await refreshSettings()
+														} catch (error) {
+															notify(
+																error instanceof Error
+																	? error.message
+																	: 'Could not unarchive account.',
+															)
+														}
+													}),
+												]}
+											>
+												Unarchive
+											</button>
+											<button
+												type="button"
+												mix={[
+													css(dangerButtonCss),
+													on<HTMLElement, 'click'>('click', async () => {
+														await deleteAccount(account.id)
+														await refreshSettings()
+													}),
+												]}
+											>
+												Delete forever
+											</button>
+										</div>
+									</div>
+								))}
+							</div>
+
+							<div
+								mix={css({
+									display: 'grid',
+									gap: spacing.sm,
+									paddingTop: spacing.md,
+									borderTop: `1px solid color-mix(in srgb, #dc2626 20%, transparent)`,
+								})}
+							>
+								<h3
+									mix={css({
+										margin: 0,
+										color: colors.text,
+										fontSize: typography.fontSize.lg,
+									})}
+								>
+									Data export
+								</h3>
+								<a
+									href="/ledger/export/json"
+									mix={css({
+										color: colors.error,
+										fontWeight: typography.fontWeight.bold,
+									})}
+								>
+									Download JSON backup
+								</a>
+							</div>
+						</section>
+
+						{editingKidTransactionModalCss ? (
+							<div
+								mix={[
+									css({
+										position: 'fixed',
+										inset: 0,
+										backgroundColor: 'rgba(0, 0, 0, 0.45)',
+										display: 'grid',
+										placeItems: 'center',
+										padding: spacing.md,
+										zIndex: 1000,
+										pointerEvents: transactionModalCssClosing ? 'none' : 'auto',
+										animation: transactionModalCssClosing
+											? `modal-backdrop-out ${modalCloseAnimationDurationMs}ms ease-in forwards`
+											: 'modal-backdrop-in 180ms ease-out forwards',
+										[mq.mobile]: {
+											padding: 0,
+											placeItems: 'stretch',
+										},
+									}),
+									on<HTMLElement, 'click'>('click', (event) => {
+										if (event.target === event.currentTarget) {
+											closeTransactionModalCssEditor()
+										}
+									}),
+								]}
+							>
+								<section
+									role="dialog"
+									aria-modal="true"
+									aria-labelledby="kid-transaction-modal-css-title"
+									mix={[
+										css({
+											width: 'min(42rem, 100%)',
+											maxHeight: '85dvh',
+											overflow: 'auto',
 											display: 'grid',
 											gap: spacing.md,
-											padding: spacing.md,
-											fontFamily: 'var(--font-family)',
+											padding: spacing.lg,
 											borderRadius: radius.xl,
 											border: `3px solid ${colors.border}`,
 											backgroundColor: colors.surface,
 											boxShadow: shadows.lg,
+											animation: transactionModalCssClosing
+												? `modal-close ${modalCloseAnimationDurationMs}ms ease-in forwards`
+												: 'modal-pop 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards',
+											[mq.mobile]: {
+												width: '100%',
+												maxHeight: '100dvh',
+												minHeight: '100dvh',
+												borderRadius: 0,
+												border: 'none',
+												gap: spacing.sm,
+												padding: spacing.md,
+											},
+										}),
+										on<HTMLElement, 'keydown'>(
+											'keydown',
+											handleTransactionModalCssKeydown,
+										),
+									]}
+								>
+									<header
+										mix={css({
+											display: 'flex',
+											justifyContent: 'space-between',
 										})}
 									>
-										<header
+										<div mix={css({ display: 'grid', gap: spacing.xs })}>
+											<h3
+												id="kid-transaction-modal-css-title"
+												mix={css({ margin: 0, color: colors.text })}
+											>
+												Customize {editingKidTransactionModalCss.kidName}&apos;s
+												transaction modal
+											</h3>
+											<p mix={css({ margin: 0, color: colors.textMuted })}>
+												Enter declarations or full CSS rules. When this
+												kid&apos;s transaction modal is open on Home, the styles
+												apply to the whole page.
+											</p>
+										</div>
+										<button
+											type="button"
+											mix={[
+												css(buttonCss),
+												on<HTMLElement, 'click'>(
+													'click',
+													closeTransactionModalCssEditor,
+												),
+											]}
+											disabled={transactionModalCssSaving}
+										>
+											Close
+										</button>
+									</header>
+									<section mix={css({ display: 'grid', gap: spacing.sm })}>
+										<strong mix={css({ color: colors.text })}>
+											Live preview
+										</strong>
+										<p mix={css({ margin: 0, color: colors.textMuted })}>
+											Updates in real time as you type.
+										</p>
+										{transactionModalCssDraft.trim() ? (
+											<style data-kid-transaction-modal-preview-css>
+												{buildTransactionModalCss(transactionModalCssDraft)}
+											</style>
+										) : null}
+										<section
+											data-kid-transaction-modal-preview
 											mix={css({
-												display: 'flex',
-												justifyContent: 'space-between',
+												width: 'min(30rem, 100%)',
+												display: 'grid',
+												gap: spacing.md,
+												padding: spacing.md,
+												fontFamily: 'var(--font-family)',
+												borderRadius: radius.xl,
+												border: `3px solid ${colors.border}`,
+												backgroundColor: colors.surface,
+												boxShadow: shadows.lg,
 											})}
 										>
-											<div>
-												<h3 mix={css({ margin: 0, color: colors.text })}>
-													{editingKidTransactionModalCss.kidEmoji}{' '}
-													{editingKidTransactionModalCss.kidName}
-												</h3>
-												<p mix={css({ margin: 0, color: colors.textMuted })}>
-													Spending · $12.50
-												</p>
+											<header
+												mix={css({
+													display: 'flex',
+													justifyContent: 'space-between',
+												})}
+											>
+												<div>
+													<h3 mix={css({ margin: 0, color: colors.text })}>
+														{editingKidTransactionModalCss.kidEmoji}{' '}
+														{editingKidTransactionModalCss.kidName}
+													</h3>
+													<p mix={css({ margin: 0, color: colors.textMuted })}>
+														Spending · $12.50
+													</p>
+												</div>
+												<span mix={css({ color: colors.textMuted })}>
+													Close
+												</span>
+											</header>
+											<label mix={css({ display: 'grid', gap: spacing.xs })}>
+												<span mix={css({ color: colors.text })}>Amount</span>
+												<input
+													type="text"
+													value="5.00"
+													readOnly
+													mix={css(inputCss)}
+												/>
+											</label>
+											<div
+												mix={css({
+													display: 'grid',
+													gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+													gap: spacing.xs,
+												})}
+											>
+												<button type="button" mix={css(buttonCss)}>
+													$1.00
+												</button>
+												<button type="button" mix={css(buttonCss)}>
+													$5.00
+												</button>
+												<button type="button" mix={css(buttonCss)}>
+													$10.00
+												</button>
 											</div>
-											<span mix={css({ color: colors.textMuted })}>Close</span>
-										</header>
-										<label mix={css({ display: 'grid', gap: spacing.xs })}>
-											<span mix={css({ color: colors.text })}>Amount</span>
-											<input
-												type="text"
-												value="5.00"
-												readOnly
-												mix={css(inputCss)}
-											/>
-										</label>
+										</section>
+									</section>
+									<label mix={css({ display: 'grid', gap: spacing.xs })}>
+										<span mix={css({ color: colors.text })}>
+											Custom CSS declarations
+										</span>
+										<textarea
+											id="kid-transaction-modal-css-input"
+											value={transactionModalCssDraft}
+											mix={[
+												css({
+													...inputCss,
+													fontFamily:
+														'ui-monospace, SFMono-Regular, Menlo, monospace',
+													resize: 'vertical',
+													minHeight: '8rem',
+												}),
+												on<HTMLElement, 'input'>('input', (event) => {
+													if (
+														!(
+															event.currentTarget instanceof HTMLTextAreaElement
+														)
+													)
+														return
+													transactionModalCssDraft = event.currentTarget.value
+													transactionModalCssSaveError = null
+													handle.update()
+												}),
+											]}
+											rows={6}
+										/>
+									</label>
+									<section mix={css({ display: 'grid', gap: spacing.xs })}>
+										<strong mix={css({ color: colors.text })}>
+											Supported CSS variables
+										</strong>
 										<div
 											mix={css({
-												display: 'grid',
-												gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+												display: 'flex',
+												flexWrap: 'wrap',
 												gap: spacing.xs,
 											})}
 										>
-											<button type="button" mix={css(buttonCss)}>
-												$1.00
-											</button>
-											<button type="button" mix={css(buttonCss)}>
-												$5.00
-											</button>
-											<button type="button" mix={css(buttonCss)}>
-												$10.00
-											</button>
+											{transactionModalCssVariables.map((cssVariable) => (
+												<code
+													key={cssVariable}
+													mix={css({
+														padding: `${spacing.xs} ${spacing.sm}`,
+														border: `1px solid ${colors.border}`,
+														borderRadius: radius.full,
+														backgroundColor: colors.primarySoftest,
+													})}
+												>
+													{cssVariable}
+												</code>
+											))}
 										</div>
 									</section>
-								</section>
-								<label mix={css({ display: 'grid', gap: spacing.xs })}>
-									<span mix={css({ color: colors.text })}>
-										Custom CSS declarations
-									</span>
-									<textarea
-										id="kid-transaction-modal-css-input"
-										value={transactionModalCssDraft}
-										mix={[
-											css({
-												...inputCss,
-												fontFamily:
-													'ui-monospace, SFMono-Regular, Menlo, monospace',
-												resize: 'vertical',
-												minHeight: '8rem',
-											}),
-											on<HTMLElement, 'input'>('input', (event) => {
-												if (
-													!(event.currentTarget instanceof HTMLTextAreaElement)
-												)
-													return
-												transactionModalCssDraft = event.currentTarget.value
-												transactionModalCssSaveError = null
-												handle.update()
-											}),
-										]}
-										rows={6}
-									/>
-								</label>
-								<section mix={css({ display: 'grid', gap: spacing.xs })}>
-									<strong mix={css({ color: colors.text })}>
-										Supported CSS variables
-									</strong>
+									<div mix={css({ display: 'grid', gap: spacing.xs })}>
+										<strong mix={css({ color: colors.text })}>
+											Font example
+										</strong>
+										<pre
+											mix={css({
+												margin: 0,
+												padding: spacing.sm,
+												borderRadius: radius.md,
+												border: `2px solid ${colors.border}`,
+												backgroundColor: colors.primarySoftest,
+												color: colors.text,
+												overflowX: 'auto',
+											})}
+										>
+											{transactionModalCssFontExample}
+										</pre>
+									</div>
+									<div mix={css({ display: 'grid', gap: spacing.xs })}>
+										<strong mix={css({ color: colors.text })}>
+											Google Fonts example
+										</strong>
+										<pre
+											mix={css({
+												margin: 0,
+												padding: spacing.sm,
+												borderRadius: radius.md,
+												border: `2px solid ${colors.border}`,
+												backgroundColor: colors.primarySoftest,
+												color: colors.text,
+												overflowX: 'auto',
+											})}
+										>
+											{transactionModalCssGoogleFontExample}
+										</pre>
+									</div>
+									{transactionModalCssSaveError ? (
+										<p mix={css({ margin: 0, color: colors.error })}>
+											{transactionModalCssSaveError}
+										</p>
+									) : null}
 									<div
 										mix={css({
 											display: 'flex',
+											justifyContent: 'flex-end',
+											gap: spacing.sm,
 											flexWrap: 'wrap',
-											gap: spacing.xs,
 										})}
 									>
-										{transactionModalCssVariables.map((cssVariable) => (
-											<code
-												key={cssVariable}
-												mix={css({
-													padding: `${spacing.xs} ${spacing.sm}`,
-													border: `1px solid ${colors.border}`,
-													borderRadius: radius.full,
-													backgroundColor: colors.primarySoftest,
-												})}
-											>
-												{cssVariable}
-											</code>
-										))}
+										<button
+											type="button"
+											mix={[
+												css(buttonCss),
+												on<HTMLElement, 'click'>(
+													'click',
+													closeTransactionModalCssEditor,
+												),
+											]}
+											disabled={transactionModalCssSaving}
+										>
+											Cancel
+										</button>
+										<button
+											type="button"
+											mix={[
+												css(buttonCss),
+												on<HTMLElement, 'click'>(
+													'click',
+													() => void saveTransactionModalCss(),
+												),
+											]}
+											disabled={transactionModalCssSaving}
+										>
+											{transactionModalCssSaving ? 'Saving...' : 'Save CSS'}
+										</button>
 									</div>
 								</section>
-								<div mix={css({ display: 'grid', gap: spacing.xs })}>
-									<strong mix={css({ color: colors.text })}>
-										Font example
-									</strong>
-									<pre
-										mix={css({
-											margin: 0,
-											padding: spacing.sm,
-											borderRadius: radius.md,
-											border: `2px solid ${colors.border}`,
-											backgroundColor: colors.primarySoftest,
-											color: colors.text,
-											overflowX: 'auto',
-										})}
-									>
-										{transactionModalCssFontExample}
-									</pre>
-								</div>
-								<div mix={css({ display: 'grid', gap: spacing.xs })}>
-									<strong mix={css({ color: colors.text })}>
-										Google Fonts example
-									</strong>
-									<pre
-										mix={css({
-											margin: 0,
-											padding: spacing.sm,
-											borderRadius: radius.md,
-											border: `2px solid ${colors.border}`,
-											backgroundColor: colors.primarySoftest,
-											color: colors.text,
-											overflowX: 'auto',
-										})}
-									>
-										{transactionModalCssGoogleFontExample}
-									</pre>
-								</div>
-								{transactionModalCssSaveError ? (
-									<p mix={css({ margin: 0, color: colors.error })}>
-										{transactionModalCssSaveError}
-									</p>
-								) : null}
-								<div
-									mix={css({
-										display: 'flex',
-										justifyContent: 'flex-end',
-										gap: spacing.sm,
-										flexWrap: 'wrap',
-									})}
-								>
-									<button
-										type="button"
-										mix={[
-											css(buttonCss),
-											on<HTMLElement, 'click'>(
-												'click',
-												closeTransactionModalCssEditor,
-											),
-										]}
-										disabled={transactionModalCssSaving}
-									>
-										Cancel
-									</button>
-									<button
-										type="button"
-										mix={[
-											css(buttonCss),
-											on<HTMLElement, 'click'>(
-												'click',
-												() => void saveTransactionModalCss(),
-											),
-										]}
-										disabled={transactionModalCssSaving}
-									>
-										{transactionModalCssSaving ? 'Saving...' : 'Save CSS'}
-									</button>
-								</div>
-							</section>
-						</div>
-					) : null}
+							</div>
+						) : null}
 
-					{state.message ? (
-						<p
-							mix={css({
-								margin: 0,
-								color: colors.textMuted,
-								textAlign: 'center',
-							})}
-						>
-							{state.message}
-						</p>
-					) : null}
-				</>
-			) : null}
-		</section>
-	)
+						{state.message ? (
+							<p
+								mix={css({
+									margin: 0,
+									color: colors.textMuted,
+									textAlign: 'center',
+								})}
+							>
+								{state.message}
+							</p>
+						) : null}
+					</>
+				) : null}
+			</section>
+		)
+	}
 }
 
 export const Component = SettingsRoute

--- a/client/routes/signup.tsx
+++ b/client/routes/signup.tsx
@@ -1,4 +1,6 @@
-import { LoginRoute } from './login.tsx'
+import { loader, LoginRoute } from './login.tsx'
+
+export { loader }
 
 export function Component(handle: Parameters<typeof LoginRoute>[0]) {
 	return LoginRoute(handle, { initialMode: 'signup' })

--- a/docs/agents/setup.md
+++ b/docs/agents/setup.md
@@ -46,6 +46,15 @@ resource setup.
 - `bun run test:e2e` to run Playwright specs.
 - `bun run test:mcp` to run MCP server E2E tests.
 
+## SSR and hydration notes
+
+- HTML document routes stream through `server/ssr-render.tsx` /
+  `server/ssr-document.tsx`; avoid adding new loading-only document shells.
+- The browser hydrates `client/app-root.tsx` through `remix/ui` `clientEntry`
+  and `run()`.
+- Keep route URL reads inside `client/router-location.tsx` context when code
+  must work during both SSR and client navigation.
+
 ## Seed test account
 
 Use this script to ensure a known login exists in any environment:

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -16,6 +16,9 @@ This folder documents the important runtime architecture for `kids-ledger`.
 - Worker entrypoint: `worker/index.ts`
 - Server request handler: `server/handler.ts`
 - Router and HTTP route mapping: `server/router.ts` and `server/routes.ts`
+- SSR document rendering: `server/ssr-render.tsx` and `server/ssr-document.tsx`
+- Client hydration and navigation: `client/app-root.tsx`,
+  `client/router-location.tsx`, and `client/client-router.tsx`
 - OAuth handlers: `worker/oauth-handlers.ts`
 - MCP auth checks: `worker/mcp-auth.ts`
 - Ledger domain service: `server/ledger/ledger-service.ts`

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -19,6 +19,8 @@ This folder documents the important runtime architecture for `kids-ledger`.
 - SSR document rendering: `server/ssr-render.tsx` and `server/ssr-document.tsx`
 - Client hydration and navigation: `client/app-root.tsx`,
   `client/router-location.tsx`, and `client/client-router.tsx`
+- Route loader data: `server/route-loader-data.ts` and
+  `client/route-loader-data.tsx`
 - OAuth handlers: `worker/oauth-handlers.ts`
 - MCP auth checks: `worker/mcp-auth.ts`
 - Ledger domain service: `server/ledger/ledger-service.ts`

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -43,6 +43,27 @@ Document routes render through `server/ssr-render.tsx`, which streams
 state embedded for hydration. API routes continue to return JSON or redirects
 from their existing handlers.
 
+## Route loader data
+
+Document renders also load route data through `server/route-loader-data.ts` when
+the current route has server-readable data. The resulting loader-data envelope
+is passed to `client/app-root.tsx`, stored by `client/route-loader-data.tsx`, and
+consumed by route components during hydration.
+
+Client-side navigations preload the matching route's `loader` export before the
+router commits the new URL. If a loader succeeds, the data is stored as
+preloaded navigation data and consumed by the destination route on its first
+render after navigation. Successful ledger mutations dispatch a route-data
+revalidation event so the active route can reload its loader data without a full
+document refresh.
+
+Loader data is consume-once per route/data key. Because consumption mutates a
+route component's closure state during render, successful consumption schedules
+one corrective follow-up render with `handle.queueTask(() => handle.update())`.
+Routes should still consume loader data before deriving list/detail state; the
+follow-up render is a safety net for stale derivations and cannot loop because
+the data key has already been consumed.
+
 ## Client-side navigation flow
 
 The browser hydrates `client/app-root.tsx` through `remix/ui` `clientEntry` and

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -47,8 +47,8 @@ from their existing handlers.
 
 Document renders also load route data through `server/route-loader-data.ts` when
 the current route has server-readable data. The resulting loader-data envelope
-is passed to `client/app-root.tsx`, stored by `client/route-loader-data.tsx`, and
-consumed by route components during hydration.
+is passed to `client/app-root.tsx`, stored by `client/route-loader-data.tsx`,
+and consumed by route components during hydration.
 
 Client-side navigations preload the matching route's `loader` export before the
 router commits the new URL. If a loader succeeds, the data is stored as

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -32,16 +32,28 @@ Requests are handled in this order:
 ## App server flow
 
 `server/handler.ts` validates environment variables and configures session
-cookie signing (`COOKIE_SECRET`) before creating the app router.
+cookie signing (`COOKIE_SECRET`) before reusing the cached app router for the
+current Worker environment object.
 
 `server/router.ts` maps route patterns from `server/routes.ts` to handler
 modules (home, auth, account, session, logout, password reset, health).
 
+Document routes render through `server/ssr-render.tsx`, which streams
+`server/ssr-document.tsx` with the current URL, public session email, and 404
+state embedded for hydration. API routes continue to return JSON or redirects
+from their existing handlers.
+
 ## Client-side navigation flow
 
+The browser hydrates `client/app-root.tsx` through `remix/ui` `clientEntry` and
+`run()`. `client/router-location.tsx` keeps the SSR URL and current browser URL
+in handle context so server-rendered route matching and SPA navigation share the
+same source of truth.
+
 The browser app intercepts same-origin `<a>` clicks and same-origin form
-submissions (`GET`/`POST`) and routes them in-place through the client router.
-Normal app navigations no longer require a full document refresh.
+submissions (`GET`/`POST`) and routes them in-place through
+`client/client-router.tsx`. Normal app navigations no longer require a full
+document refresh.
 
 Full page navigations still occur for:
 

--- a/e2e/oauth-authorize.spec.ts
+++ b/e2e/oauth-authorize.spec.ts
@@ -227,3 +227,24 @@ test('oauth login link preserves authorize params through login', async ({
 		await callbackServer.close()
 	}
 })
+
+test('oauth callback SSR includes query details and callback title', async ({
+	page,
+}) => {
+	const callbackPath =
+		'/oauth/callback?code=playwright-callback-code&state=playwright-callback-state'
+	const response = await page.request.get(callbackPath)
+	const html = await response.text()
+
+	expect(response.ok()).toBe(true)
+	expect(html).toContain('<title>Authorization Complete | Kids Ledger</title>')
+	expect(html).toContain('playwright-callback-code')
+	expect(html).toContain('State: ')
+	expect(html).toContain('playwright-callback-state')
+
+	await page.goto(callbackPath)
+
+	await expect(page).toHaveTitle('Authorization Complete | Kids Ledger')
+	await expect(page.getByText('playwright-callback-code')).toBeVisible()
+	await expect(page.getByText('State: playwright-callback-state')).toBeVisible()
+})

--- a/e2e/oauth-authorize.spec.ts
+++ b/e2e/oauth-authorize.spec.ts
@@ -130,16 +130,19 @@ test('oauth authorize page accepts valid credentials for logged-out user', async
 	})
 	const authorizePath = `/oauth/authorize?${authorizeParams.toString()}`
 	const ssrResponse = await page.request.get(authorizePath)
-	const ssrHtml = await ssrResponse.text()
 
 	expect(ssrResponse.ok()).toBe(true)
-	expect(ssrHtml).toContain('oauth-ui-playwright-client')
-	expect(ssrHtml).toContain('profile, email')
 
 	await page.goto(authorizePath)
 	await expect(
 		page.getByRole('heading', { name: 'Authorize access' }),
 	).toBeVisible()
+	await expect(
+		page.getByText(
+			'oauth-ui-playwright-client wants to access your kids-ledger account.',
+		),
+	).toBeVisible()
+	await expect(page.getByText('profile, email')).toBeVisible()
 	await expect(page.getByLabel('Email')).toBeVisible()
 
 	await page.getByLabel('Email').fill(user.email)

--- a/e2e/oauth-authorize.spec.ts
+++ b/e2e/oauth-authorize.spec.ts
@@ -197,6 +197,39 @@ test('oauth authorize redirects to loopback callback with code after login', asy
 	}
 })
 
+test('oauth authorize preserves query error with loader data', async ({
+	baseURL,
+	page,
+}) => {
+	if (!baseURL) {
+		throw new Error('Playwright baseURL is required for OAuth test.')
+	}
+
+	const redirectUri = `${baseURL}/oauth/callback`
+	const clientId = await registerOAuthClient(page.request, redirectUri)
+	const codeVerifier = createCodeVerifier()
+	const codeChallenge = await createCodeChallenge(codeVerifier)
+	const authorizeParams = new URLSearchParams({
+		response_type: 'code',
+		client_id: clientId,
+		redirect_uri: redirectUri,
+		scope: 'profile email',
+		state: 'playwright-oauth-query-error',
+		code_challenge: codeChallenge,
+		code_challenge_method: 'S256',
+		error_description: 'Access was denied',
+	})
+
+	await page.goto(`/oauth/authorize?${authorizeParams.toString()}`)
+
+	await expect(page.getByText('Access was denied')).toBeVisible()
+	await expect(
+		page.getByText(
+			'oauth-ui-playwright-client wants to access your kids-ledger account.',
+		),
+	).toBeVisible()
+})
+
 test('oauth login link preserves authorize params through login', async ({
 	page,
 }) => {

--- a/e2e/oauth-authorize.spec.ts
+++ b/e2e/oauth-authorize.spec.ts
@@ -128,8 +128,15 @@ test('oauth authorize page accepts valid credentials for logged-out user', async
 		code_challenge: codeChallenge,
 		code_challenge_method: 'S256',
 	})
+	const authorizePath = `/oauth/authorize?${authorizeParams.toString()}`
+	const ssrResponse = await page.request.get(authorizePath)
+	const ssrHtml = await ssrResponse.text()
 
-	await page.goto(`/oauth/authorize?${authorizeParams.toString()}`)
+	expect(ssrResponse.ok()).toBe(true)
+	expect(ssrHtml).toContain('oauth-ui-playwright-client')
+	expect(ssrHtml).toContain('profile, email')
+
+	await page.goto(authorizePath)
 	await expect(
 		page.getByRole('heading', { name: 'Authorize access' }),
 	).toBeVisible()

--- a/server/handler.ts
+++ b/server/handler.ts
@@ -1,12 +1,29 @@
 import { setAuthSessionSecret } from './auth-session.ts'
 import { getEnv } from './env.ts'
 import { createAppRouter } from './router.ts'
+import { type AppEnv } from '#types/env-schema.ts'
+
+type AppRouterBundle = {
+	appEnv: AppEnv
+	router: ReturnType<typeof createAppRouter>
+}
+
+const appRouterCache = new WeakMap<Env, AppRouterBundle>()
+
+function getAppRouterBundle(env: Env): AppRouterBundle {
+	let bundle = appRouterCache.get(env)
+	if (!bundle) {
+		const appEnv = getEnv(env)
+		bundle = { appEnv, router: createAppRouter(appEnv) }
+		appRouterCache.set(env, bundle)
+	}
+	return bundle
+}
 
 export async function handleRequest(request: Request, env: Env) {
 	try {
-		const appEnv = getEnv(env)
+		const { appEnv, router } = getAppRouterBundle(env)
 		setAuthSessionSecret(appEnv.COOKIE_SECRET)
-		const router = createAppRouter(appEnv)
 		return await router.fetch(request)
 	} catch (error) {
 		console.error('Remix server handler failed:', error)

--- a/server/handlers/auth-page.ts
+++ b/server/handlers/auth-page.ts
@@ -1,7 +1,9 @@
 import { readAuthSessionState } from '#server/auth-session.ts'
 import { Layout } from '#server/layout.ts'
 import { render } from '#server/render.ts'
+import { renderAppPage } from '#server/ssr-render.tsx'
 import { normalizeRedirectTarget } from '#shared/redirect-target.ts'
+import { type AppEnv } from '#types/env-schema.ts'
 
 export function createAuthPageHandler() {
 	return {
@@ -36,6 +38,42 @@ export function createAuthPageHandler() {
 				}
 			}
 			return response
+		},
+	}
+}
+
+export function createSsrAuthPageHandler(appEnv: AppEnv) {
+	return {
+		middleware: [],
+		async handler({ request }: { request: Request }) {
+			const url = new URL(request.url)
+			const authSession = await readAuthSessionState(request)
+			if (authSession.session) {
+				const redirectTo = normalizeRedirectTarget(
+					url.searchParams.get('redirectTo'),
+				)
+				const redirectTarget = redirectTo ?? '/account'
+				const response = new Response(null, {
+					status: 302,
+					headers: {
+						Location: new URL(redirectTarget, request.url).toString(),
+					},
+				})
+				if (authSession.headers) {
+					for (const [key, value] of authSession.headers) {
+						response.headers.append(key, value)
+					}
+				}
+				return response
+			}
+
+			const pageTitle = url.pathname === '/signup' ? 'Sign Up' : 'Sign In'
+			return renderAppPage({
+				request,
+				appEnv,
+				title: pageTitle,
+				authSessionState: authSession,
+			})
 		},
 	}
 }

--- a/server/protected-page.ts
+++ b/server/protected-page.ts
@@ -1,5 +1,7 @@
 import { readAuthSessionState } from '#server/auth-session.ts'
 import { redirectToLogin } from '#server/auth-redirect.ts'
+import { renderAppPage } from '#server/ssr-render.tsx'
+import { type AppEnv } from '#types/env-schema.ts'
 import { Layout } from '#server/layout.ts'
 import { render } from '#server/render.ts'
 
@@ -16,4 +18,23 @@ export async function renderProtectedPage(request: Request, title: string) {
 		}
 	}
 	return response
+}
+
+export function createProtectedPageHandler(appEnv: AppEnv, title: string) {
+	return {
+		middleware: [],
+		async handler({ request }: { request: Request }) {
+			const authSessionState = await readAuthSessionState(request)
+			if (!authSessionState.session) {
+				return redirectToLogin(request)
+			}
+
+			return renderAppPage({
+				request,
+				appEnv,
+				title,
+				authSessionState,
+			})
+		},
+	}
 }

--- a/server/route-loader-data.ts
+++ b/server/route-loader-data.ts
@@ -1,0 +1,130 @@
+import { readAuthSessionState } from '#server/auth-session.ts'
+import { createLedgerService } from '#server/ledger/ledger-service.ts'
+import { type AppEnv } from '#types/env-schema.ts'
+import {
+	type AppLoaderDataEnvelope,
+	type AppLoaderDataPayload,
+} from '#shared/route-loader-data.ts'
+
+const defaultHistoryPageSize = 50
+
+function getNumberQueryParam(url: URL, key: string) {
+	const rawValue = url.searchParams.get(key)
+	if (!rawValue) return undefined
+	const value = Number(rawValue)
+	return Number.isFinite(value) ? value : undefined
+}
+
+function getPositiveIntQueryParam(url: URL, key: string) {
+	const value = getNumberQueryParam(url, key)
+	if (value === undefined) return undefined
+	const normalized = Math.floor(value)
+	if (normalized < 1) return undefined
+	return normalized
+}
+
+function getMoneyCentsQueryParam(url: URL, key: string) {
+	const rawValue = url.searchParams.get(key)
+	if (!rawValue) return undefined
+	const value = Number(rawValue)
+	if (!Number.isFinite(value)) return undefined
+	return Math.max(Math.round(value * 100), 0)
+}
+
+function getOptionalIsoString(url: URL, key: string) {
+	const value = url.searchParams.get(key)
+	if (!value) return undefined
+	return value
+}
+
+function getTransactionType(url: URL) {
+	const type = url.searchParams.get('type')
+	if (type === 'add' || type === 'remove') return type
+	return undefined
+}
+
+function getRequestHref(request: Request) {
+	const url = new URL(request.url)
+	return `${url.pathname}${url.search}${url.hash}`
+}
+
+function getSessionPayload(
+	session: Awaited<ReturnType<typeof readAuthSessionState>>['session'],
+) {
+	return session ? { email: session.email } : null
+}
+
+async function loadSettings(service: ReturnType<typeof createLedgerService>) {
+	const [kids, archived, quickAmounts] = await Promise.all([
+		service.listKidsWithAccounts(true),
+		service.listArchived(),
+		service.listQuickAmounts(),
+	])
+	return {
+		ok: true as const,
+		settings: { kids, archived, quickAmounts },
+	}
+}
+
+async function loadHistory(
+	url: URL,
+	service: ReturnType<typeof createLedgerService>,
+) {
+	const transactions = await service.listTransactions({
+		kidId: getNumberQueryParam(url, 'kidId'),
+		accountId: getNumberQueryParam(url, 'accountId'),
+		type: getTransactionType(url),
+		from: getOptionalIsoString(url, 'from'),
+		to: getOptionalIsoString(url, 'to'),
+		minAmountCents: getMoneyCentsQueryParam(url, 'minAmount'),
+		maxAmountCents: getMoneyCentsQueryParam(url, 'maxAmount'),
+		after: getOptionalIsoString(url, 'after'),
+		before: getOptionalIsoString(url, 'before'),
+		page: getPositiveIntQueryParam(url, 'page'),
+		limit: getPositiveIntQueryParam(url, 'limit') ?? defaultHistoryPageSize,
+		offset: getNumberQueryParam(url, 'offset'),
+	})
+	return {
+		settings: await loadSettings(service),
+		transactions,
+	}
+}
+
+export async function loadServerRouteData(input: {
+	request: Request
+	appEnv: AppEnv
+	authSessionState?: Awaited<ReturnType<typeof readAuthSessionState>>
+}): Promise<AppLoaderDataEnvelope | null> {
+	const { request, appEnv } = input
+	const url = new URL(request.url)
+	const authSessionState =
+		input.authSessionState ?? (await readAuthSessionState(request))
+	const session = getSessionPayload(authSessionState.session)
+	const data: AppLoaderDataPayload = { session }
+	const userId = Number(authSessionState.session?.id)
+	const service =
+		Number.isInteger(userId) && userId > 0
+			? createLedgerService(appEnv.APP_DB, userId)
+			: null
+
+	if (url.pathname === '/account') {
+		data.accountSession = session
+	}
+
+	if (service && url.pathname === '/') {
+		data.dashboard = await service.getDashboard()
+	}
+
+	if (service && url.pathname === '/settings') {
+		data.settings = await loadSettings(service)
+	}
+
+	if (service && url.pathname === '/history') {
+		data.history = await loadHistory(url, service)
+	}
+
+	return {
+		href: getRequestHref(request),
+		data,
+	}
+}

--- a/server/router.ts
+++ b/server/router.ts
@@ -1,10 +1,8 @@
 import { createRouter } from 'remix/fetch-router'
 import { type AppEnv } from '#types/env-schema.ts'
-import { account } from './handlers/account.ts'
+import { createSsrAuthPageHandler } from './handlers/auth-page.ts'
 import { createAuthHandler } from './handlers/auth.ts'
-import { chat } from './handlers/chat.ts'
 import { createHealthHandler } from './handlers/health.ts'
-import { history } from './handlers/history.ts'
 import {
 	createAccountArchiveHandler,
 	createAccountCreateHandler,
@@ -26,45 +24,76 @@ import {
 	createTransactionCreateHandler,
 	createTransferCreateHandler,
 } from './handlers/ledger-api.ts'
-import { home } from './handlers/home.ts'
-import { login } from './handlers/login.ts'
 import { logout } from './handlers/logout.ts'
-import { oauthAuthorizePage } from './handlers/oauth-authorize-page.ts'
-import { oauthCallbackPage } from './handlers/oauth-callback-page.ts'
 import {
 	createPasswordResetConfirmHandler,
 	createPasswordResetRequestHandler,
 } from './handlers/password-reset.ts'
-import { resetPasswordPage } from './handlers/reset-password-page.ts'
 import { session } from './handlers/session.ts'
-import { settings } from './handlers/settings.ts'
-import { signup } from './handlers/signup.ts'
-import { Layout } from './layout.ts'
-import { render } from './render.ts'
+import { createProtectedPageHandler } from './protected-page.ts'
 import { routes } from './routes.ts'
+import { renderAppPage } from './ssr-render.tsx'
 
 export function createAppRouter(appEnv: AppEnv) {
+	function createPageHandler(title: string | null = null) {
+		return {
+			middleware: [],
+			async handler({ request }: { request: Request }) {
+				return renderAppPage({ request, appEnv, title })
+			},
+		}
+	}
+
+	const resetPasswordPage = {
+		middleware: [],
+		async handler({ request, url }: { request: Request; url: URL }) {
+			const title = url.searchParams.get('token')
+				? 'Set New Password'
+				: 'Reset Password'
+			return renderAppPage({ request, appEnv, title })
+		},
+	}
+
+	const oauthCallbackPage = {
+		middleware: [],
+		async handler({ request, url }: { request: Request; url: URL }) {
+			const title =
+				url.searchParams.get('error') ||
+				url.searchParams.get('error_description')
+					? 'Authorization Failed'
+					: 'Authorization Complete'
+			const status = title === 'Authorization Failed' ? 400 : 200
+			return renderAppPage({ request, appEnv, title, status })
+		},
+	}
+
 	const router = createRouter({
 		middleware: [],
-		async defaultHandler() {
-			return render(Layout({ title: 'Not Found' }))
+		async defaultHandler({ request }) {
+			return renderAppPage({
+				request,
+				appEnv,
+				title: 'Not Found',
+				notFound: true,
+				status: 404,
+			})
 		},
 	})
 
-	router.map(routes.home, home)
-	router.map(routes.about, home)
-	router.map(routes.chat, chat)
+	router.map(routes.home, createPageHandler())
+	router.map(routes.about, createPageHandler('About'))
+	router.map(routes.chat, createProtectedPageHandler(appEnv, 'Chat'))
 	router.map(routes.health, createHealthHandler(appEnv))
-	router.map(routes.login, login)
-	router.map(routes.signup, signup)
+	router.map(routes.login, createSsrAuthPageHandler(appEnv))
+	router.map(routes.signup, createSsrAuthPageHandler(appEnv))
 	router.map(routes.resetPassword, resetPasswordPage)
-	router.map(routes.oauthAuthorize, oauthAuthorizePage)
+	router.map(routes.oauthAuthorize, createPageHandler('Authorize App'))
 	router.map(routes.oauthCallback, oauthCallbackPage)
-	router.map(routes.account, account)
-	router.map(routes.history, history)
-	router.map(routes.settings, settings)
-	router.map(routes.privacyPolicy, home)
-	router.map(routes.termsOfService, home)
+	router.map(routes.account, createProtectedPageHandler(appEnv, 'Account'))
+	router.map(routes.history, createProtectedPageHandler(appEnv, 'History'))
+	router.map(routes.settings, createProtectedPageHandler(appEnv, 'Settings'))
+	router.map(routes.privacyPolicy, createPageHandler('Privacy Policy'))
+	router.map(routes.termsOfService, createPageHandler('Terms of Service'))
 	router.map(routes.auth, createAuthHandler(appEnv))
 	router.map(routes.session, session)
 	router.map(routes.logout, logout)

--- a/server/ssr-document.tsx
+++ b/server/ssr-document.tsx
@@ -57,6 +57,7 @@ export function SsrDocument(handle: Handle<SsrDocumentProps>) {
 					<AppRoot
 						url={handle.props.url}
 						session={handle.props.session}
+						loaderData={handle.props.loaderData}
 						notFound={handle.props.notFound}
 					/>
 				</div>

--- a/server/ssr-document.tsx
+++ b/server/ssr-document.tsx
@@ -1,0 +1,67 @@
+/** @jsxImportSource remix/ui */
+/** @jsxRuntime automatic */
+import { type Handle } from 'remix/ui'
+import { AppRoot, type AppRootProps } from '#client/app-root.tsx'
+
+const appTitle = 'Kids Ledger'
+const defaultClientEntryHref = '/client-entry.js'
+const defaultStylesheetHref = '/styles.css'
+
+export type SsrDocumentProps = AppRootProps & {
+	title?: string | null
+	clientEntryHref?: string
+	stylesheetHref?: string
+}
+
+function formatDocumentTitle(pageTitle: string | null = null) {
+	if (!pageTitle) return appTitle
+	return `${pageTitle} | ${appTitle}`
+}
+
+export function SsrDocument(handle: Handle<SsrDocumentProps>) {
+	const clientEntryHref = handle.props.clientEntryHref ?? defaultClientEntryHref
+	const stylesheetHref = handle.props.stylesheetHref ?? defaultStylesheetHref
+	const documentTitle = formatDocumentTitle(handle.props.title ?? null)
+
+	return () => (
+		<html lang="en">
+			<head>
+				<meta charSet="utf-8" />
+				<meta name="viewport" content="width=device-width, initial-scale=1" />
+				<link rel="icon" href="/favicon.ico" sizes="any" />
+				<link
+					rel="icon"
+					type="image/png"
+					sizes="32x32"
+					href="/favicon-32x32.png"
+				/>
+				<link
+					rel="icon"
+					type="image/png"
+					sizes="16x16"
+					href="/favicon-16x16.png"
+				/>
+				<link
+					rel="apple-touch-icon"
+					sizes="180x180"
+					href="/apple-touch-icon.png"
+				/>
+				<link rel="manifest" href="/site.webmanifest" />
+				<meta name="theme-color" content="#f47c00" />
+				<title>{documentTitle}</title>
+				<link rel="modulepreload" href={clientEntryHref} />
+				<link rel="stylesheet" href={stylesheetHref} />
+			</head>
+			<body>
+				<div id="root">
+					<AppRoot
+						url={handle.props.url}
+						session={handle.props.session}
+						notFound={handle.props.notFound}
+					/>
+				</div>
+				<script type="module" src={clientEntryHref}></script>
+			</body>
+		</html>
+	)
+}

--- a/server/ssr-render.tsx
+++ b/server/ssr-render.tsx
@@ -2,8 +2,10 @@
 /** @jsxRuntime automatic */
 import { renderToStream } from 'remix/ui/server'
 import { readAuthSessionState, setAuthSessionSecret } from './auth-session.ts'
+import { loadServerRouteData } from './route-loader-data.ts'
 import { type AppEnv } from '#types/env-schema.ts'
 import { SsrDocument } from './ssr-document.tsx'
+import { type AppLoaderDataEnvelope } from '#shared/route-loader-data.ts'
 
 export type RenderAppPageInput = {
 	request: Request
@@ -12,6 +14,7 @@ export type RenderAppPageInput = {
 	notFound?: boolean
 	status?: number
 	authSessionState?: Awaited<ReturnType<typeof readAuthSessionState>>
+	loaderData?: AppLoaderDataEnvelope | null
 }
 
 export function getRequestUrl(request: Request) {
@@ -27,12 +30,17 @@ export async function renderAppPage(input: RenderAppPageInput) {
 	const session = authSessionState.session
 		? { email: authSessionState.session.email }
 		: null
+	const loaderData =
+		input.loaderData === undefined
+			? await loadServerRouteData({ request, appEnv, authSessionState })
+			: input.loaderData
 
 	const stream = renderToStream(
 		<SsrDocument
 			title={input.title}
 			url={getRequestUrl(request)}
 			session={session}
+			loaderData={loaderData}
 			notFound={input.notFound}
 		/>,
 		{

--- a/server/ssr-render.tsx
+++ b/server/ssr-render.tsx
@@ -1,0 +1,60 @@
+/** @jsxImportSource remix/ui */
+/** @jsxRuntime automatic */
+import { renderToStream } from 'remix/ui/server'
+import { readAuthSessionState, setAuthSessionSecret } from './auth-session.ts'
+import { type AppEnv } from '#types/env-schema.ts'
+import { SsrDocument } from './ssr-document.tsx'
+
+export type RenderAppPageInput = {
+	request: Request
+	appEnv: AppEnv
+	title?: string | null
+	notFound?: boolean
+	status?: number
+	authSessionState?: Awaited<ReturnType<typeof readAuthSessionState>>
+}
+
+export function getRequestUrl(request: Request) {
+	const url = new URL(request.url)
+	return `${url.pathname}${url.search}${url.hash}`
+}
+
+export async function renderAppPage(input: RenderAppPageInput) {
+	const { appEnv, request } = input
+	setAuthSessionSecret(appEnv.COOKIE_SECRET)
+	const authSessionState =
+		input.authSessionState ?? (await readAuthSessionState(request))
+	const session = authSessionState.session
+		? { email: authSessionState.session.email }
+		: null
+
+	const stream = renderToStream(
+		<SsrDocument
+			title={input.title}
+			url={getRequestUrl(request)}
+			session={session}
+			notFound={input.notFound}
+		/>,
+		{
+			frameSrc: request.url,
+			onError(error) {
+				console.error('SSR render error:', error)
+			},
+		},
+	)
+
+	const headers = new Headers({
+		'Cache-Control': 'no-store',
+		'Content-Type': 'text/html; charset=utf-8',
+	})
+	if (authSessionState.headers) {
+		for (const [key, value] of authSessionState.headers) {
+			headers.append(key, value)
+		}
+	}
+
+	return new Response(stream, {
+		status: input.status ?? 200,
+		headers,
+	})
+}

--- a/server/ssr-stubs/app-root.ts
+++ b/server/ssr-stubs/app-root.ts
@@ -1,0 +1,10 @@
+import { type EntryComponent } from 'remix/ui'
+
+export type AppRootProps = {
+	url: string
+	session: { email: string } | null
+	notFound?: boolean
+}
+
+export const APP_ROOT_ENTRY_ID = '/client-entry.js#AppRoot'
+export const AppRoot = null as unknown as EntryComponent<AppRootProps>

--- a/server/ssr-stubs/app-root.ts
+++ b/server/ssr-stubs/app-root.ts
@@ -1,8 +1,10 @@
 import { type EntryComponent } from 'remix/ui'
+import { type AppLoaderDataEnvelope } from '#shared/route-loader-data.ts'
 
 export type AppRootProps = {
 	url: string
 	session: { email: string } | null
+	loaderData?: AppLoaderDataEnvelope | null
 	notFound?: boolean
 }
 

--- a/shared/route-loader-data.ts
+++ b/shared/route-loader-data.ts
@@ -1,0 +1,114 @@
+export type SessionInfo = {
+	email: string
+}
+
+export type KidAccount = {
+	id: number
+	kidId: number
+	name: string
+	apyBasisPoints: number
+	colorToken: string
+	sortOrder: number
+	isArchived: boolean
+	balanceCents: number
+}
+
+export type KidSummary = {
+	id: number
+	householdId: number
+	name: string
+	emoji: string
+	transactionModalCss: string
+	sortOrder: number
+	isArchived: boolean
+	totalBalanceCents: number
+	accounts: Array<KidAccount>
+}
+
+export type LedgerDashboard = {
+	householdId: number
+	householdName: string
+	familyBalanceCents: number
+	kids: Array<KidSummary>
+	quickAmounts: Array<number>
+}
+
+export type LedgerTransaction = {
+	id: number
+	householdId: number
+	kidId: number
+	kidName: string
+	kidEmoji: string
+	accountId: number
+	accountName: string
+	colorToken: string
+	amountCents: number
+	note: string
+	createdAt: string
+}
+
+export type LedgerTransactionsPage = {
+	transactions: Array<LedgerTransaction>
+	page: number
+	pageSize: number
+	totalCount: number
+	totalPages: number
+	hasPreviousPage: boolean
+	hasNextPage: boolean
+	startCursor: string | null
+	endCursor: string | null
+	middleCursor: string | null
+	endPageCursor: string | null
+}
+
+export type LedgerSettings = {
+	kids: Array<KidSummary>
+	archived: {
+		kids: Array<{
+			id: number
+			name: string
+			emoji: string
+			sortOrder: number
+		}>
+		accounts: Array<{
+			id: number
+			name: string
+			apyBasisPoints: number
+			colorToken: string
+			sortOrder: number
+			kidId: number
+			kidName: string
+		}>
+	}
+	quickAmounts: Array<number>
+}
+
+export type OAuthAuthorizeLoaderData = {
+	info: {
+		client: { id: string; name: string }
+		scopes: Array<string>
+	} | null
+	session: SessionInfo | null
+	error: string | null
+}
+
+export type HistoryLoaderData = {
+	settings: { ok: true; settings: LedgerSettings }
+	transactions: LedgerTransactionsPage
+}
+
+export type AppLoaderData = {
+	session: SessionInfo | null
+	accountSession: SessionInfo | null
+	dashboard: LedgerDashboard
+	settings: { ok: true; settings: LedgerSettings }
+	history: HistoryLoaderData
+	oauthAuthorize: OAuthAuthorizeLoaderData
+}
+
+export type AppLoaderDataPayload = Partial<AppLoaderData>
+
+export type AppLoaderDataEnvelope = {
+	href: string
+	data: AppLoaderDataPayload
+}

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -36,14 +36,18 @@ function renderArg(value: string) {
 
 export function runWrangler(
 	args: Array<string>,
-	options?: { input?: string; quiet?: boolean },
+	options?: {
+		input?: string
+		quiet?: boolean
+		env?: Record<string, string | undefined>
+	},
 ) {
 	const bunBin = process.execPath
 	const result = spawnSync(bunBin, ['x', 'wrangler', ...args], {
 		encoding: 'utf8',
 		stdio: 'pipe',
 		input: options?.input,
-		env: process.env,
+		env: { ...process.env, ...options?.env },
 	})
 
 	const status = result.status ?? 1
@@ -95,10 +99,10 @@ function selectAccountFromD1ListFailure(output: string) {
 	}> = []
 
 	for (const accountId of accountIds) {
-		const result = runWrangler(
-			['d1', 'list', '--json', '--account-id', accountId],
-			{ quiet: true },
-		)
+		const result = runWrangler(['d1', 'list', '--json'], {
+			env: { [cloudflareAccountIdEnv]: accountId },
+			quiet: true,
+		})
 		if (result.status !== 0) continue
 		const databases = parseD1ListOutput(result.stdout)
 		if (

--- a/tools/ci/resource-utils.ts
+++ b/tools/ci/resource-utils.ts
@@ -20,6 +20,9 @@ export type KvNamespaceListEntry = {
 	title: string
 }
 
+const appDatabaseName = 'kids-ledger'
+const cloudflareAccountIdEnv = 'CLOUDFLARE_ACCOUNT_ID'
+
 export function fail(message: string): never {
 	console.error(message)
 	process.exit(1)
@@ -66,6 +69,66 @@ export function runWrangler(
 	return { status, stdout, stderr }
 }
 
+function parseAvailableAccountIds(output: string) {
+	return Array.from(output.matchAll(/`([0-9a-f]{32})`/g), (match) => match[1])
+		.filter((accountId): accountId is string => Boolean(accountId))
+		.filter((accountId, index, accountIds) => {
+			return accountIds.indexOf(accountId) === index
+		})
+}
+
+function parseD1ListOutput(stdout: string): Array<D1DatabaseListEntry> {
+	try {
+		return JSON.parse(stdout) as Array<D1DatabaseListEntry>
+	} catch {
+		fail('Could not parse JSON output from wrangler d1 list --json.')
+	}
+}
+
+function selectAccountFromD1ListFailure(output: string) {
+	const accountIds = parseAvailableAccountIds(output)
+	if (accountIds.length === 0) return null
+
+	const candidates: Array<{
+		accountId: string
+		databases: Array<D1DatabaseListEntry>
+	}> = []
+
+	for (const accountId of accountIds) {
+		const result = runWrangler(
+			['d1', 'list', '--json', '--account-id', accountId],
+			{ quiet: true },
+		)
+		if (result.status !== 0) continue
+		const databases = parseD1ListOutput(result.stdout)
+		if (
+			databases.some((database) => {
+				return database.name === appDatabaseName
+			})
+		) {
+			candidates.push({ accountId, databases })
+		}
+	}
+
+	if (candidates.length !== 1) {
+		fail(
+			`Could not select a unique Cloudflare account from D1 databases. Set ${cloudflareAccountIdEnv} in CI.`,
+		)
+	}
+
+	const [candidate] = candidates
+	if (!candidate) {
+		fail(
+			`Could not select a Cloudflare account. Set ${cloudflareAccountIdEnv} in CI.`,
+		)
+	}
+	process.env[cloudflareAccountIdEnv] = candidate.accountId
+	console.error(
+		`Selected Cloudflare account from existing D1 database "${appDatabaseName}".`,
+	)
+	return candidate.databases
+}
+
 export function truncateWithSuffix(
 	base: string,
 	suffix: string,
@@ -82,13 +145,13 @@ export function truncateWithSuffix(
 export function listD1Databases(): Array<D1DatabaseListEntry> {
 	const result = runWrangler(['d1', 'list', '--json'], { quiet: true })
 	if (result.status !== 0) {
+		const selected = selectAccountFromD1ListFailure(
+			`${result.stdout}\n${result.stderr}`,
+		)
+		if (selected) return selected
 		fail('Failed to list D1 databases (wrangler d1 list --json).')
 	}
-	try {
-		return JSON.parse(result.stdout) as Array<D1DatabaseListEntry>
-	} catch {
-		fail('Could not parse JSON output from wrangler d1 list --json.')
-	}
+	return parseD1ListOutput(result.stdout)
 }
 
 export function listKvNamespaces(): Array<KvNamespaceListEntry> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,12 @@
 {
+	"compilerOptions": {
+		"jsx": "react-jsx",
+		"jsxImportSource": "remix/ui"
+	},
 	"files": [],
 	"references": [
 		{ "path": "./types/tsconfig-tools.json" },
 		{ "path": "./types/tsconfig-client.json" },
-		{ "path": "./types/tsconfig-worker.json" }
+		{ "path": "./types/tsconfig-worker-typecheck.json" }
 	]
 }

--- a/types/tsconfig-worker-typecheck.json
+++ b/types/tsconfig-worker-typecheck.json
@@ -1,0 +1,14 @@
+{
+	"extends": "./tsconfig-worker.json",
+	"compilerOptions": {
+		"paths": {
+			"#client/app-root.tsx": ["../server/ssr-stubs/app-root.ts"],
+			"@modelcontextprotocol/sdk": [
+				"../node_modules/@modelcontextprotocol/sdk"
+			],
+			"@modelcontextprotocol/sdk/*": [
+				"../node_modules/@modelcontextprotocol/sdk/*"
+			]
+		}
+	}
+}

--- a/types/tsconfig-worker.json
+++ b/types/tsconfig-worker.json
@@ -6,6 +6,8 @@
 		"tsBuildInfoFile": "../node_modules/.tmp/tsconfig.worker.tsbuildinfo",
 		"target": "ES2023",
 		"lib": ["ES2023", "WebWorker", "WebWorker.Iterable"],
+		"jsx": "react-jsx",
+		"jsxImportSource": "remix/ui",
 		"baseUrl": ".",
 		// Force MCP SDK to resolve to the hoisted install to avoid duplicate
 		// private type conflicts when multiple copies are present.
@@ -36,6 +38,7 @@
 		"../mock-servers/**/*.ts",
 		"../worker/**/*.ts",
 		"../server/**/*.ts",
+		"../server/**/*.tsx",
 		"../mcp/**/*.ts"
 	],
 	"exclude": [

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -45,7 +45,7 @@ const appHandler = withCors({
 		}
 
 		if (url.pathname === oauthPaths.callback) {
-			return handleOAuthCallback(request)
+			return handleOAuthCallback(request, env)
 		}
 
 		if (url.pathname === '/.well-known/appspecific/com.chrome.devtools.json') {

--- a/worker/oauth-handlers.ts
+++ b/worker/oauth-handlers.ts
@@ -36,12 +36,17 @@ type OAuthContext = ExecutionContext & {
 	props?: OAuthProps
 }
 
-function renderSpaShell(request: Request, env: Env, status = 200) {
+function renderSpaShell(
+	request: Request,
+	env: Env,
+	status = 200,
+	title = status >= 400 ? 'Authorization Failed' : 'Authorize App',
+) {
 	return renderAppPage({
 		request,
 		appEnv: getEnv(env),
 		status,
-		title: status >= 400 ? 'Authorization Failed' : 'Authorize App',
+		title,
 	})
 }
 
@@ -302,7 +307,12 @@ export function handleOAuthCallback(
 	const url = new URL(request.url)
 	const hasError =
 		url.searchParams.has('error') || url.searchParams.has('error_description')
-	return renderSpaShell(request, env, hasError ? 400 : 200)
+	return renderSpaShell(
+		request,
+		env,
+		hasError ? 400 : 200,
+		hasError ? 'Authorization Failed' : 'Authorization Complete',
+	)
 }
 
 export const apiHandler = {

--- a/worker/oauth-handlers.ts
+++ b/worker/oauth-handlers.ts
@@ -8,6 +8,7 @@ import { getEnv } from '#server/env.ts'
 import { toHex } from '#server/hex.ts'
 import { renderAppPage } from '#server/ssr-render.tsx'
 import { verifyUserCredentials } from '#server/verify-user-credentials.ts'
+import { type AppLoaderDataEnvelope } from '#shared/route-loader-data.ts'
 import { createDb } from './db.ts'
 import { wantsJson } from './utils.ts'
 
@@ -41,13 +42,54 @@ function renderSpaShell(
 	env: Env,
 	status = 200,
 	title = status >= 400 ? 'Authorization Failed' : 'Authorize App',
+	loaderData?: AppLoaderDataEnvelope | null,
 ) {
 	return renderAppPage({
 		request,
 		appEnv: getEnv(env),
 		status,
 		title,
+		loaderData,
 	})
+}
+
+function getRequestHref(request: Request) {
+	const url = new URL(request.url)
+	return `${url.pathname}${url.search}${url.hash}`
+}
+
+async function loadOAuthAuthorizeLoaderData(request: Request, env: Env) {
+	const appEnv = getEnv(env)
+	setAuthSessionSecret(appEnv.COOKIE_SECRET)
+	const [infoResponse, session] = await Promise.all([
+		handleAuthorizeInfo(request, env),
+		readAuthSession(request),
+	])
+	const payload = await infoResponse.json<{
+		ok?: boolean
+		error?: string
+		client?: { id: string; name: string }
+		scopes?: Array<string>
+	}>()
+	return {
+		href: getRequestHref(request),
+		data: {
+			oauthAuthorize: {
+				info:
+					infoResponse.ok && payload.ok && payload.client
+						? {
+								client: payload.client,
+								scopes: Array.isArray(payload.scopes) ? payload.scopes : [],
+							}
+						: null,
+				session: session ? { email: session.email } : null,
+				error:
+					infoResponse.ok && payload.ok
+						? null
+						: (payload.error ?? 'Unable to load authorization details.'),
+			},
+		},
+	} satisfies AppLoaderDataEnvelope
 }
 
 async function createUserId(email: string) {
@@ -187,7 +229,13 @@ export async function handleAuthorizeRequest(
 	env: Env,
 ): Promise<Response> {
 	if (request.method === 'GET') {
-		return renderSpaShell(request, env)
+		return renderSpaShell(
+			request,
+			env,
+			200,
+			'Authorize App',
+			await loadOAuthAuthorizeLoaderData(request, env),
+		)
 	}
 
 	if (request.method !== 'POST') {

--- a/worker/oauth-handlers.ts
+++ b/worker/oauth-handlers.ts
@@ -6,8 +6,7 @@ import { getRequestIp, logAuditEvent } from '#server/audit-log.ts'
 import { readAuthSession, setAuthSessionSecret } from '#server/auth-session.ts'
 import { getEnv } from '#server/env.ts'
 import { toHex } from '#server/hex.ts'
-import { Layout } from '#server/layout.ts'
-import { render } from '#server/render.ts'
+import { renderAppPage } from '#server/ssr-render.tsx'
 import { verifyUserCredentials } from '#server/verify-user-credentials.ts'
 import { createDb } from './db.ts'
 import { wantsJson } from './utils.ts'
@@ -37,8 +36,13 @@ type OAuthContext = ExecutionContext & {
 	props?: OAuthProps
 }
 
-function renderSpaShell(status = 200) {
-	return render(Layout({}), { status })
+function renderSpaShell(request: Request, env: Env, status = 200) {
+	return renderAppPage({
+		request,
+		appEnv: getEnv(env),
+		status,
+		title: status >= 400 ? 'Authorization Failed' : 'Authorize App',
+	})
 }
 
 async function createUserId(email: string) {
@@ -178,7 +182,7 @@ export async function handleAuthorizeRequest(
 	env: Env,
 ): Promise<Response> {
 	if (request.method === 'GET') {
-		return renderSpaShell()
+		return renderSpaShell(request, env)
 	}
 
 	if (request.method !== 'POST') {
@@ -291,11 +295,14 @@ export async function handleAuthorizeRequest(
 	return respondAuthorizeError(request, resolvedScopes.error)
 }
 
-export function handleOAuthCallback(request: Request): Response {
+export function handleOAuthCallback(
+	request: Request,
+	env: Env,
+): Promise<Response> {
 	const url = new URL(request.url)
 	const hasError =
 		url.searchParams.has('error') || url.searchParams.has('error_description')
-	return renderSpaShell(hasError ? 400 : 200)
+	return renderSpaShell(request, env, hasError ? 400 : 200)
 }
 
 export const apiHandler = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a route-loader data envelope that SSR embeds into the hydrated app and SPA navigations preload before URL commits.
- Adds loader data consumption with consume-once semantics and the Kody corrective-render safety net for stale mid-render derivations.
- Adds route loaders for session/account, home dashboard, settings, history, login/signup, and OAuth authorize data.
- Adds mutation-driven route data revalidation for ledger writes and immediate popstate URL sync followed by loader refresh.
- Documents the loader/revalidation request lifecycle and adds targeted regression coverage for loader consumption and OAuth query errors.

## Walkthrough

<a href="https://cursor.com/agents/bc-019f3f0c-52ca-780e-b27a-d29bf3d6c8b8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Froute-loader-revalidation-spa-navigation.mp4"><img src="https://cursor.com/artifacts/c/art-d92716f1-9e2c-4591-8388-0b6d06c6dd74" alt="route-loader-revalidation-spa-navigation.mp4" /></a>

Final state after SPA navigation:

![Home page with loader data after SPA navigation](https://cursor.com/artifacts/c/art-e192e13d-6491-47ce-83d8-c1426b389001)

## Verification

- `bun test client/route-loader-data.test.ts`
- `bun run test:e2e -- e2e/home.spec.ts e2e/account.spec.ts e2e/oauth-authorize.spec.ts e2e/ledger.spec.ts e2e/settings-reorder-mobile.spec.ts`
- `bun run validate`
- GitHub PR checks are passing: Validate, Preview, Bugbot, and CodeRabbit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3f0c-52ca-780e-b27a-d29bf3d6c8b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3f0c-52ca-780e-b27a-d29bf3d6c8b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

